### PR TITLE
TLS.1x标准的SM2双向认证过程发现一些问题 请指正或参考

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ make
 sudo make install
 ```
 
+在WIN32(MINGW+MSYS)操作系统上通过如下指令实现编译和安装：
+
+(请在MSYS环境解压或Git clone代码，否则会因换行符导致出现编译错误)
+
+```
+./config
+make
+make install
+```
+

--- a/crypto/skf/skf.h
+++ b/crypto/skf/skf.h
@@ -99,6 +99,28 @@ typedef UINT32			DWORD;
 typedef UINT32			FLAGS;
 typedef CHAR *			LPSTR;
 typedef void *			HANDLE;
+#else
+#ifndef _WINDEF_H
+typedef signed char		INT8;
+typedef signed short		INT16;
+typedef signed int		INT32;
+typedef unsigned char		UINT8;
+typedef unsigned short		UINT16;
+typedef unsigned int		UINT32;
+typedef long			BOOL;
+typedef UINT8			BYTE;
+typedef UINT8			CHAR;
+typedef INT16			SHORT;
+typedef UINT16			USHORT;
+typedef INT32			LONG;
+typedef UINT32			ULONG;
+typedef UINT32			UINT;
+typedef UINT16			WORD;
+typedef UINT32			DWORD;
+typedef UINT32			FLAGS;
+typedef CHAR *			LPSTR;
+typedef void *			HANDLE;
+#endif
 #endif
 
 typedef HANDLE DEVHANDLE;

--- a/crypto/x509/x509_d2.c
+++ b/crypto/x509/x509_d2.c
@@ -88,11 +88,11 @@ int X509_STORE_load_locations(X509_STORE *ctx, const char *file,
     X509_LOOKUP *lookup;
     
     //Support Go: 
-    //Go调用此函数无法传递NULL指针,只能传递空串。
+    //Go璋冪敤姝ゅ嚱鏁颁紶閫掔┖涓叉椂澶勭悊寮傚父
     if (file && *file == '\0')
 	file = NULL; 
     if (path && *path == '\0')
-	path = NULL 	
+	path = NULL; 	
 
     if (file != NULL) {
         lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_file());

--- a/crypto/x509/x509_d2.c
+++ b/crypto/x509/x509_d2.c
@@ -86,6 +86,13 @@ int X509_STORE_load_locations(X509_STORE *ctx, const char *file,
                               const char *path)
 {
     X509_LOOKUP *lookup;
+    
+    //Support Go: 
+    //Go调用此函数无法传递NULL指针,只能传递空串。
+    if (file && *file == '\0')
+	file = NULL; 
+    if (path && *path == '\0')
+	path = NULL 	
 
     if (file != NULL) {
         lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_file());

--- a/ssl/s3_clnt.c
+++ b/ssl/s3_clnt.c
@@ -1872,6 +1872,12 @@ int ssl3_get_key_exchange(SSL *s)
                 X509_get_pubkey(s->session->
                                 sess_cert->peer_pkeys[SSL_PKEY_ECC].x509);
 # endif
+# ifndef NO_GMSSL
+        else if (alg_a & SSL_aSM2)
+            pkey =
+                X509_get_pubkey(s->session->
+                                sess_cert->peer_pkeys[SSL_PKEY_ECC].x509);
+# endif
         /* else anonymous ECDH, so no certificate or pkey. */
         EC_KEY_set_public_key(ecdh, srvr_ecpoint);
         s->session->sess_cert->peer_ecdh_tmp = ecdh;

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -163,7 +163,40 @@ const char ssl3_version_str[] = "SSLv3" OPENSSL_VERSION_PTEXT;
 
 /* list of available SSLv3 ciphers (sorted by id) */
 OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
+# ifndef NO_GMSSL
+	/* (GmSSL specific) */
+	{
+		1,
+		GM1_TXT_ECDHE_SM2_SM4_SM3,
+		GM1_CK_ECDHE_SM2_SM4_SM3,
+		SSL_kEECDH,
+		SSL_aSM2,
+		SSL_SM4,
+		SSL_SM3,
+		SSL_TLSV1_2,
+		SSL_NOT_EXP|SSL_HIGH,
+		SSL_HANDSHAKE_MAC_DEFAULT|TLS1_PRF,
+		128,
+		128,
+	},
 
+	/* (GmSSL Specific) */
+	{
+		1,
+		GM1_TXT_SM2_SM4_SM3,
+		GM1_CK_SM2_SM4_SM3,
+		SSL_kSM2,
+		SSL_aSM2,
+		SSL_SM4,
+		SSL_SM3,
+		SSL_TLSV1_2,
+		SSL_NOT_EXP|SSL_HIGH,
+		SSL_HANDSHAKE_MAC_DEFAULT|TLS1_PRF,
+		128,
+		128,
+	}
+# endif
+#if 0
 /* The RSA ciphers */
 /* Cipher 01 */
     {
@@ -2890,42 +2923,7 @@ OPENSSL_GLOBAL SSL_CIPHER ssl3_ciphers[] = {
      256,
      256},
 #endif
-
-#ifndef NO_GMSSL
-	/* (GmSSL specific) */
-	{
-		1,
-		GM1_TXT_ECDHE_SM2_SM4_SM3,
-		GM1_CK_ECDHE_SM2_SM4_SM3,
-		SSL_kEECDH,
-		SSL_aSM2,
-		SSL_SM4,
-		SSL_SM3,
-		SSL_TLSV1_2,
-		SSL_NOT_EXP|SSL_HIGH,
-		SSL_HANDSHAKE_MAC_DEFAULT|TLS1_PRF,
-		128,
-		128,
-	},
-
-	/* (GmSSL Specific) */
-	{
-		1,
-		GM1_TXT_SM2_SM4_SM3,
-		GM1_CK_SM2_SM4_SM3,
-		SSL_kSM2,
-		SSL_aSM2,
-		SSL_SM4,
-		SSL_SM3,
-		SSL_TLSV1_2,
-		SSL_NOT_EXP|SSL_HIGH,
-		SSL_HANDSHAKE_MAC_DEFAULT|TLS1_PRF,
-		128,
-		128,
-	}
-
 #endif
-
 /* end of list */
 };
 

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -2128,7 +2128,12 @@ int ssl_cipher_get_cert_index(const SSL_CIPHER *c)
          * chosen.
          */
         return SSL_PKEY_ECC;
-    } else if (alg_a & SSL_aECDSA)
+    } 
+# ifndef NO_GMSSL
+    else if (alg_a & SSL_aSM2)
+        return SSL_PKEY_ECC;
+# endif
+    else if (alg_a & SSL_aECDSA)
         return SSL_PKEY_ECC;
     else if (alg_k & SSL_kDHr)
         return SSL_PKEY_DH_RSA;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2585,9 +2585,16 @@ EVP_PKEY *ssl_get_sign_pkey(SSL *s, const SSL_CIPHER *cipher,
             idx = SSL_PKEY_RSA_SIGN;
         else if (c->pkeys[SSL_PKEY_RSA_ENC].privatekey != NULL)
             idx = SSL_PKEY_RSA_ENC;
-    } else if ((alg_a & SSL_aECDSA) &&
+    } 
+# ifndef NO_GMSSL	
+	 else if ((alg_a & SSL_aSM2) &&
                (c->pkeys[SSL_PKEY_ECC].privatekey != NULL))
         idx = SSL_PKEY_ECC;
+# endif
+	else if ((alg_a & SSL_aECDSA) &&
+               (c->pkeys[SSL_PKEY_ECC].privatekey != NULL))
+        idx = SSL_PKEY_ECC;
+
     if (idx == -1) {
         SSLerr(SSL_F_SSL_GET_SIGN_PKEY, ERR_R_INTERNAL_ERROR);
         return (NULL);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2414,6 +2414,12 @@ void ssl_set_cert_masks(CERT *c, const SSL_CIPHER *cipher)
             emask_a |= SSL_aECDSA;
         }
 # endif
+# ifndef NO_GMSSL
+            mask_a |= SSL_aSM2;
+            emask_a |= SSL_aSM2;
+            mask_k |= SSL_kSM2;
+            emask_k |= SSL_kSM2;	
+# endif
     }
 #endif
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1026,6 +1026,10 @@ static int tls1_check_cert_param(SSL *s, X509 *x, int set_ee_md)
                 tlsext_sigalg_ecdsa(md)
 
 static unsigned char tls12_sigalgs[] = {
+# ifndef NO_GMSSL
+        TLSEXT_hash_sm3,
+        TLSEXT_signature_sm2sign,
+# endif
 # ifndef OPENSSL_NO_SHA512
     tlsext_sigalg(TLSEXT_hash_sha512)
         tlsext_sigalg(TLSEXT_hash_sha384)


### PR DESCRIPTION
说明：
主要使用GMSSL做个项目：
客户端与服务器均使用GMSSL库，客户端位于WIN+MINGW编译环境, 服务端位于Linux +GCC。

问题：
强制双向证书认证+指定SM2套件发现SSL握手失败。

修正：
1、修正Win32+MINGW+MSYS下编译不过
2、使用GMSSL做双向认证发现无法像Wiki说的支持TLS1.x的两个SM2套件， 代码做了调整。
3、去掉非SM2的套件（项目不允许，代码一起带过来了，请忽略）
