### PR TITLE
README.md中SM2里pkeyutl -verify例子，应该增加-pubin，否则无法运行。

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ GmSSL是一个开源的密码工具箱，支持SM2/SM3/SM4/SM9等国密(国家�
 
    ```sh
    $ gmssl pkey -pubout -in signkey.pem -out vrfykey.pem
-   $ gmssl pkeyutl -verify -pkeyopt ec_sign_algor:sm2 -inkey vrfykey.pem \
+   $ gmssl pkeyutl -verify -pkeyopt ec_sign_algor:sm2 -pubin -inkey vrfykey.pem \
                    -in <yourfile> -sigfile <yourfile>.sig
    ```
 


### PR DESCRIPTION
如题。
目前没加-pubin，pkeyutl -verify会把给的vrfykey.pem作为私钥，从而不能正常解析vrfykey.pem。
应增加-pubin，使其把vrfykey.pem作为公钥