### PR TITLE
Update e_sms4.c

### DIFF
--- a/crypto/evp/e_sms4.c
+++ b/crypto/evp/e_sms4.c
@@ -87,7 +87,7 @@ static int sms4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 	if ((mode == EVP_CIPH_ECB_MODE || mode == EVP_CIPH_CBC_MODE) && !enc) {
 		sms4_set_decrypt_key(&dat->ks, key);
 	} else {
-		sms4_set_decrypt_key(&dat->ks, key);
+		sms4_set_encrypt_key(&dat->ks, key);
 	}
 	dat->block = (block128_f)sms4_encrypt;
 	dat->stream.cbc = mode == EVP_CIPH_CBC_MODE ? (cbc128_f) sms4_cbc_encrypt : NULL;


### PR DESCRIPTION
加密时应采用sms4_set_encrypt_key， 否则导致gmtls在协商最后一个finished时客户端或服务端无法正确解密。
  