### PR TITLE
Allow GO API to build for linux and other platforms;

### DIFF
--- a/go/gmssl/build.go
+++ b/go/gmssl/build.go
@@ -3,7 +3,7 @@
 package gmssl
 
 /*
-#cgo darwin CFLAGS: -I/usr/local/include
-#cgo darwin LDFLAGS: -L/usr/local/lib -lcrypto
+#cgo CFLAGS: -I../../include
+#cgo LDFLAGS: -L../../ -lcrypto
 */
 import "C"


### PR DESCRIPTION
Without the change , building is only allowed for MacOS, for Linux platform it will fail. 
And change it to be using relative include and link path, otherwise some errors will be seen such as 
"could not determine kind of name for C.EVP_MD_CTX_free" if you don't install the header file to system path. 