### PR TITLE
o2i_SM2CiphertextValue成功时，返回前遗漏将cv置空，导致返回值被释放

### DIFF
--- a/crypto/sm2/sm2_oct.c
+++ b/crypto/sm2/sm2_oct.c
@@ -272,6 +272,7 @@ SM2CiphertextValue *o2i_SM2CiphertextValue(const EC_GROUP *group,
 	/* set result */
 	*pin = p;
 	ret = cv;
+	cv = NULL;
 
 end:
 	SM2CiphertextValue_free(cv);


### PR DESCRIPTION
第一次pull request，如果操作有误，请见谅