### PR TITLE
Fix unnecessary free in o2i_SM2CiphertextValue

### DIFF
--- a/crypto/sm2/sm2_oct.c
+++ b/crypto/sm2/sm2_oct.c
@@ -272,6 +272,7 @@ SM2CiphertextValue *o2i_SM2CiphertextValue(const EC_GROUP *group,
 	/* set result */
 	*pin = p;
 	ret = cv;
+	cv = NULL;
 
 end:
 	SM2CiphertextValue_free(cv);


### PR DESCRIPTION
The caller will crash when using the return value from
o2i_SM2CiphertextValue. Because the returned pointer to SM2CiphertextValue has been free,
regardless of success or failure in this method.

When assign cv to ret, cv should be set NULL just like the behaviour in
SM2_do_encrypt.