### PR TITLE
Fix SKF and SDF engines build error

### DIFF
--- a/engines/sdf_dummy.c
+++ b/engines/sdf_dummy.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <openssl/sgd.h>
 #include <openssl/sdf.h>
+#include <openssl/engine.h>
 
 static char *deviceHandle = "SDF Device Handle";
 static char *sessionHandle = "SDF Session Handle";
@@ -471,7 +472,7 @@ int SDF_GenerateAgreementDataWithECC(
 	ECCrefPublicKey *pucSponsorTmpPublicKey,
 	void **phAgreementHandle)
 {
-	// any output public key ? 			
+	// any output public key ?
 	if (!phAgreementHandle || !(*phAgreementHandle))
 		return SDR_INARGERR;
 	*phAgreementHandle = agreementHandle;
@@ -509,7 +510,7 @@ int SDF_GenerateAgreementDataAndKeyWithECC(
 	ECCrefPublicKey *pucResponseTmpPublicKey,
 	void **phKeyHandle)
 {
-	// any output 				
+	// any output
 	if (!phKeyHandle || !(*phKeyHandle))
 		return SDR_INARGERR;
 	*phKeyHandle = keyHandle;
@@ -766,3 +767,10 @@ int SDF_DeleteFile(
 {
 	return SDR_OK;
 }
+
+static int bind(ENGINE *e, const char *id)
+{
+	return 1;
+}
+IMPLEMENT_DYNAMIC_BIND_FN(bind)
+IMPLEMENT_DYNAMIC_CHECK_FN()

--- a/engines/skf_dummy.c
+++ b/engines/skf_dummy.c
@@ -53,6 +53,7 @@
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/gmskf.h>
+#include <openssl/engine.h>
 
 static char *hDeviceHandle	= "hDeviceHandle";
 static char *hApplication	= "hApplication";
@@ -962,3 +963,10 @@ ULONG DEVAPI SKF_CloseHandle(
 {
 	return SAR_OK;
 }
+
+static int bind(ENGINE *e, const char *id)
+{
+	return 1;
+}
+IMPLEMENT_DYNAMIC_BIND_FN(bind)
+IMPLEMENT_DYNAMIC_CHECK_FN()


### PR DESCRIPTION
When build dynamic library on Windows, build errors occur on SKF and SDF
engines build. Because when the engines are compiled into a
self-contained dll, bind_engine and v_check are needed which has been
exported in def file.

Add missing methods here to resolve the build error.

Because the engines are dummy implemented, the methods added here are
also dummy.

Ref：
https://www.openssl.org/blog/blog/2015/11/23/engine-building-lesson-2-an-example-md5-engine/

This build error has been mentioned at issue#399