### PR TITLE
sm2: fix cv free error, in o2i_SM2CiphertextValue() function

### DIFF
--- a/crypto/sm2/sm2_oct.c
+++ b/crypto/sm2/sm2_oct.c
@@ -274,7 +274,9 @@ SM2CiphertextValue *o2i_SM2CiphertextValue(const EC_GROUP *group,
 	ret = cv;
 
 end:
-	SM2CiphertextValue_free(cv);
+	if ((cv != *pout) && (!ret))
+		SM2CiphertextValue_free(cv);
+
 	EC_POINT_free(point);
 	BN_CTX_free(bn_ctx);
 	return ret;


### PR DESCRIPTION
SM2 密文格式转换接口 `o2i_SM2CiphertextValue()` 中对 `cv` 的释放似乎缺少判断，释放的条件为：

1. cv 为接口内部分配的资源
2. 处理过程中发生错误

其他条件则不对 cv 进行释放操作，比如接口外完成的 cv 申请.
