### PR TITLE
fix sm3 padding bug

### DIFF
--- a/crypto/sm3/sm3.c
+++ b/crypto/sm3/sm3.c
@@ -110,8 +110,8 @@ void sm3_final(sm3_ctx_t *ctx, unsigned char *digest)
 		memset(ctx->block, 0, SM3_BLOCK_SIZE - 8);
 	}
 
-	count[0] = cpu_to_be32((ctx->nblocks) >> 23);
-	count[1] = cpu_to_be32((ctx->nblocks << 9) + (ctx->num << 3));
+	count[0] = cpu_to_be32((uint32_t)(ctx->nblocks >> 23));
+	count[1] = cpu_to_be32((uint32_t)(ctx->nblocks << 9) + (ctx->num << 3));
 
 	sm3_compress(ctx->digest, ctx->block);
 	for (i = 0; i < sizeof(ctx->digest)/sizeof(ctx->digest[0]); i++) {

--- a/include/openssl/sm3.h
+++ b/include/openssl/sm3.h
@@ -70,7 +70,7 @@ extern "C" {
 
 typedef struct {
 	uint32_t digest[8];
-	int nblocks;
+	uint64_t nblocks;
 	unsigned char block[64];
 	int num;
 } sm3_ctx_t;


### PR DESCRIPTION
用openssl做参照，测试gmssl的sm3时，发现数据在256MB到512MB之间时（768MB到1024MB同理），二者digest不一致。后来发现如下两点问题：
1.sm3 padding 的程序中有移位操作，count[1] = cpu_to_be32((ctx->nblocks << 9) + (ctx->num << 3));
而ctx->nblocks是一个有符号整型，当其左移后，最高位为1时，该位会被移位到符号位。
当执行cpu_to_be32这个函数时，会进行大小端转换，内部会有右移操作。
由于有符号数和无符号数右移的时候，左边补的数不同，无符号数补0，有符号数补符号位，这就会导致count[1]出现错误。
2.sm3 spec要求，补位的bit len是64位的，所以这里的ctx->nblocks必须要大于64-9=55位，所以修改ctx->nblocks为64位无符号类型。
修改后的代码已经测试了256MB到512MB，768MB到1024MB，以及（2^61-64）byte的几组数据，测试都是正确的