### PR TITLE
Sm2 bugfix

### DIFF
--- a/go/gmssl/engine.go
+++ b/go/gmssl/engine.go
@@ -95,7 +95,6 @@ func NewEngineByName(name string) (*Engine, error) {
 	ret := &Engine{eng}
 	runtime.SetFinalizer(ret, func(ret *Engine) {
 		C.ENGINE_finish(ret.engine)
-		C.ENGINE_free(ret.engine)
 	})
 	if 1 != C.ENGINE_init(eng) {
 		return nil, GetErrors()


### PR DESCRIPTION
并没有使用ENGINE_new就调用了ENGINE_free，使得程序运行到该析构函数时提示析构了空指针。由于go语言的SetFinalizer函数在程序结束时并不一定会被调用，所以现有程序并不会运行到该行代码，但是现有代码多次运行就会遇到该问题。删除C.ENGINE_free(ret.engine)该行即可解决问题。