### PR TITLE
Update byteorder.h

### DIFF
--- a/include/internal/byteorder.h
+++ b/include/internal/byteorder.h
@@ -51,7 +51,7 @@
 #define HEADER_BYTEORDER_H
 
 
-#ifdef CPU_BIGENDIAN
+#ifdef B_ENDIAN
 
 #define cpu_to_be16(v) (v)
 #define cpu_to_be32(v) (v)


### PR DESCRIPTION
config脚本可以自动识别大小端机器，如果是大端会在编译选项里添加-DB_ENDIAN选项，所以我们这里的宏CPU_BIGENDIAN替换成B_ENDIAN就支持自动识别了, 这样就避免了不知道CPU_BIGENDIAN宏的人在大端机上编译出错误的版本了。