### PR TITLE
fix bug LNK2001

### DIFF
--- a/crypto/sm2/build.info
+++ b/crypto/sm2/build.info
@@ -1,3 +1,3 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=sm2_err.c sm2_asn1.c sm2_id.c sm2_sign.c sm2_enc.c \
-			sm2_oct.c sm2_exch.c sm2_kmeth.c
+			sm2_oct.c sm2_exch.c sm2_kmeth.c sm2_cosign.c


### PR DESCRIPTION
fix bug  LNK2001 unresolved external symbol SM2_cosigner1_generate_proof
...
The file crypto\sm2\sm2_cosign. c is not compiled, so add it to build. info