### PR TITLE
bug fixed: no fixed order in map may cause GeneratePrivateKey error

### DIFF
--- a/go/gmssl/pkey.go
+++ b/go/gmssl/pkey.go
@@ -672,6 +672,8 @@ func GeneratePrivateKey(alg string, args [][2]string, eng *Engine) (*PrivateKey,
 	defer C.free(unsafe.Pointer(calg))
 
 	ctx := C.new_pkey_keygen_ctx(calg, nil)
+	defer C.EVP_PKEY_CTX_free(ctx)
+
 	/*
 	if eng != nil {
 		ctx := C.new_pkey_keygen_ctx(calg, eng.engine)
@@ -890,6 +892,7 @@ func (pk *PublicKey) Encrypt(alg string, in []byte, eng *Engine) ([]byte, error)
 	if out == nil {
 		return nil, GetErrors()
 	}
+	defer C.free(unsafe.Pointer(out))
 	return C.GoBytes(unsafe.Pointer(out), C.int(outlen)), nil
 }
 
@@ -902,6 +905,7 @@ func (sk *PrivateKey) Decrypt(alg string, in []byte, eng *Engine) ([]byte, error
 	if out == nil {
 		return nil, GetErrors()
 	}
+	defer C.free(unsafe.Pointer(out))
 	return C.GoBytes(unsafe.Pointer(out), C.int(outlen)), nil
 }
 
@@ -915,6 +919,7 @@ func (sk *PrivateKey) Sign(alg string, dgst []byte, eng *Engine) ([]byte, error)
 		C.ERR_print_errors_fp(C.stderr)
 		return nil, GetErrors()
 	}
+	defer C.free(unsafe.Pointer(sig))
 	return C.GoBytes(unsafe.Pointer(sig), C.int(siglen)), nil
 }
 
@@ -938,6 +943,7 @@ func (sk *PrivateKey) DeriveKey(alg string, peer PublicKey, eng *Engine) ([]byte
 	if key == nil {
 		return nil, GetErrors()
 	}
+	defer C.free(unsafe.Pointer(key))
 	return C.GoBytes(unsafe.Pointer(key), C.int(keylen)), nil
 }
 

--- a/go/gmssl/pkey.go
+++ b/go/gmssl/pkey.go
@@ -667,7 +667,7 @@ type PrivateKey struct {
 	pkey *C.EVP_PKEY
 }
 
-func GeneratePrivateKey(alg string, args map[string]string, eng *Engine) (*PrivateKey, error) {
+func GeneratePrivateKey(alg string, args [][2]string, eng *Engine) (*PrivateKey, error) {
 	calg := C.CString(alg)
 	defer C.free(unsafe.Pointer(calg))
 
@@ -688,7 +688,9 @@ func GeneratePrivateKey(alg string, args map[string]string, eng *Engine) (*Priva
 		if 1 != C.EVP_PKEY_paramgen_init(ctx) {
 			return nil, GetErrors()
 		}
-		for name, value := range args {
+		for _, arg := range args {
+			name := arg[0]
+			value := arg[1]
 			cname := C.CString(name)
 			defer C.free(unsafe.Pointer(cname))
 			cvalue := C.CString(value)
@@ -712,7 +714,9 @@ func GeneratePrivateKey(alg string, args map[string]string, eng *Engine) (*Priva
 			return nil, GetErrors()
 		}
 
-		for name, value := range args {
+		for _, arg := range args {
+			name := arg[0]
+			value := arg[1]
 			cname := C.CString(name)
 			defer C.free(unsafe.Pointer(cname))
 			cvalue := C.CString(value)

--- a/go/gmssltest/gmssltest.go
+++ b/go/gmssltest/gmssltest.go
@@ -149,9 +149,9 @@ func main() {
 	fmt.Println()
 
 	/* private key */
-	rsa_args := map[string]string {
-		"rsa_keygen_bits": "2048",
-		"rsa_keygen_pubexp" : "65537",
+	rsa_args := [][2]string{
+		{"rsa_keygen_bits", "2048"},
+		{"rsa_keygen_pubexp", "65537"},
 	}
 
 	rsa, err := gmssl.GeneratePrivateKey("RSA", rsa_args, nil)
@@ -175,9 +175,9 @@ func main() {
 	fmt.Println()
 
 	/* SM2 key pair operations */
-	sm2keygenargs := map[string]string {
-		"ec_paramgen_curve": "sm2p256v1",
-		"ec_param_enc": "named_curve",
+	sm2keygenargs := [][2]string{
+		{"ec_paramgen_curve", "sm2p256v1"},
+		{"ec_param_enc", "named_curve"},
 	}
 	sm2sk, _ := gmssl.GeneratePrivateKey("EC", sm2keygenargs, nil)
 	sm2sktxt, _ := sm2sk.GetText()


### PR DESCRIPTION
1. 此map被遍历时出来的元素顺序不固定，会偶尔导致 GeneratePrivateKey 出错。
`
	sm2keygenargs := map[string]string {
		"ec_paramgen_curve": "sm2p256v1",
		"ec_param_enc": "named_curve",
	}
	sm2sk, _ := gmssl.GeneratePrivateKey("EC", sm2keygenargs, nil)
`

`
140105295136512:error:1010C0B1:elliptic curve routines:pkey_ec_ctrl:no parameters set:crypto/ec/ec_pmeth.c:391
`

改成数组解决问题。

2. 修正内存泄漏若干