### PR TITLE
sm2_bmi2_bugfix

### DIFF
--- a/crypto/ec/asm/ecp_sm2z256-x86_64.pl
+++ b/crypto/ec/asm/ecp_sm2z256-x86_64.pl
@@ -1267,6 +1267,9 @@ __ecp_sm2z256_sqr_montx:
 	 shrx	$a_ptr, $acc0, $t4
 	 mov	.Lpoly+8*3(%rip), $t1
 
+    # set of = 0
+    add \$0, $acc2
+
 	# reduction step 1
 	xor	$t1, $t1
 	adox	$acc0, $acc1
@@ -1281,6 +1284,9 @@ __ecp_sm2z256_sqr_montx:
 	shlx	$a_ptr, $acc1, $t0
 	shrx	$a_ptr, $acc1, $t4
 
+    # set of = 0
+    add \$0, $acc2
+
 	# reduction step 2
 	adox	$acc1, $acc2
 	adox	$t1, $acc3
@@ -1294,6 +1300,9 @@ __ecp_sm2z256_sqr_montx:
 	shlx	$a_ptr, $acc2, $t0
 	shrx	$a_ptr, $acc2, $t4
 
+    # set of = 0
+    add \$0, $acc2
+
 	# reduction step 3
 	adox	$acc2, $acc3
 	adox	$t1, $acc0
@@ -1306,6 +1315,9 @@ __ecp_sm2z256_sqr_montx:
 
 	shlx	$a_ptr, $acc3, $t0
 	shrx	$a_ptr, $acc3, $t4
+
+    # set of = 0
+    add \$0, $acc2
 
 	# reduction step 4
 	adox	$acc3, $acc0


### PR DESCRIPTION
#951、 #941 等issue提到SM2验签有很小的概率会失败，原因和解决方法如下。

ecp_sm2z256-x86_64.pl中函数__ecp_sm2z256_sqr_montx 1272，1285，1298，1311行使用加法指令adox，在支持BMI2指令的CPU上会造成偶发的验签失败。

原因是这里的加法应该不带进位(参考函数__ecp_sm2z256_sqr_montq 920，936，952，968行，使用的是add指令)，而adox是带进位的（OF=1的时候会加一）。

失败的概率非常低，平均大概几十万次会错一次，这是因为OF是由之前的sbb指令决定的[(sbb)](https://www.felixcloutier.com/x86/sbb)，只有当有符号减法借位时会设OF=1，而实际执行sbb时候是64位整数减32位整数，几乎不可能借位。

在这4个adox指令前加上add \$0, $acc2这类指令就可以设置OF=0，不会再出现偶发的验签失败。