### PR TITLE
解决972 issue中的编译链接报错问题

### DIFF
--- a/test/sm9test.c
+++ b/test/sm9test.c
@@ -416,13 +416,13 @@ int main(int argc, char **argv)
 
 	RAND_seed(rnd_seed, sizeof(rnd_seed));
 
-	/*
+#if SM9_TEST
 	if (!rate_test()) {
 		printf("sm9 rate pairing test failed\n");
 		err++;
 	} else
 		printf("sm9 rate pairing test passed\n");
-	*/
+#endif
 
 	if (!sm9test_sign(id, in, sizeof(in)-1, use_test_vector)) {
 		printf("sm9 sign tests failed\n");


### PR DESCRIPTION
sm9_rate.c: L2704~L2754使用宏开关定义rate_test方法，测试用例test/sm9test.c中调用到rate_test方法的位置和定义时保持一致使用SM9_TEST宏开关包起来, 解决编译链接报错的问题。
```
#if SM9_TEST
static int rate_test(void)
{
	const char *Ppubs_str[] = {
		"29DBA116152D1F786CE843ED24A3B573414D2177386A92DD8F14D65696EA5E32",
		"9F64080B3084F733E48AFF4B41B565011CE0711C5E392CFB0AB1B6791B94C408",
		"41E00A53DDA532DA1A7CE027B7A46F741006E85F5CDFF0730E75C05FB4E3216D",
		"69850938ABEA0112B57329F447E3A0CBAD3E2FDB1A77F335E89E1408D0EF1C25"};
	const char *g_str[] = {
		"AAB9F06A4EEBA4323A7833DB202E4E35639D93FA3305AF73F0F071D7D284FCFB",
		"84B87422330D7936EABA1109FA5A7A7181EE16F2438B0AEB2F38FD5F7554E57A",
		"4C744E69C4A2E1C8ED72F796D151A17CE2325B943260FC460B9F73CB57C9014B",
		"B3129A75D31D17194675A1BC56947920898FBF390A5BF5D931CE6CBB3340F66D",
		"93634F44FA13AF76169F3CC8FBEA880ADAFF8475D5FD28A75DEB83C44362B439",
		"1604A3FCFA9783E667CE9FCB1062C2A5C6685C316DDA62DE0548BAA6BA30038B",
		"5A1AE172102EFD95DF7338DBC577C66D8D6C15E0A0158C7507228EFB078F42A6",
		"67E0E0C2EED7A6993DCE28FE9AA2EF56834307860839677F96685F2B44D0911F",
		"A01F2C8BEE81769609462C69C96AA923FD863E209D3CE26DD889B55E2E3873DB",
		"38BFFE40A22D529A0C66124B2C308DAC9229912656F62B4FACFCED408E02380F",
		"28B3404A61908F5D6198815C99AF1990C8AF38655930058C28C21BB539CE0000",
		"4E378FB5561CD0668F906B731AC58FEE25738EDF09CADC7A29C0ABC0177AEA6D"};

	BN_CTX *ctx = NULL;
	EC_GROUP *group = NULL;
	const EC_POINT *P1;
	point_t Ppubs;
	fp12_t g;
	int ok;

	ctx = BN_CTX_new();
	BN_CTX_start(ctx);
	group = EC_GROUP_new_by_curve_name(NID_sm9bn256v1);
	P1 = EC_GROUP_get0_generator(group);

	point_init(&Ppubs, ctx);
	point_set_affine_coordinates_hex(&Ppubs, Ppubs_str);

	fp12_init(g, ctx);
	rate_pairing(g, &Ppubs, P1, ctx);

	ok = fp12_equ_hex(g, g_str, ctx);
	printf("rate %d: %s\n", __LINE__, ok ? "ok" : "error");

	fp12_cleanup(g);
	point_cleanup(&Ppubs);
	EC_GROUP_free(group);
	BN_CTX_free(ctx);

	return 1;
}
#endif
```
