### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 
 language: c


### PR DESCRIPTION
According to [Ubuntu Release](https://wiki.ubuntu.com/Releases) 
`End of Standard Support` of `trusty` is April 2019
We should bump to Ubuntu 16.04.6 LTS "xenial"