### PR TITLE
gmssl req命令支持为skf ukey生成CSR

### DIFF
--- a/crypto/gmapi/gmapi_skf_ec.c
+++ b/crypto/gmapi/gmapi_skf_ec.c
@@ -83,12 +83,12 @@ int EC_KEY_set_ECCPUBLICKEYBLOB(EC_KEY *ec_key, const ECCPUBLICKEYBLOB *blob)
 	int ret = 0;
 	BIGNUM *x = NULL;
 	BIGNUM *y = NULL;
-
+	/*
 	if ((int)blob->BitLen != EC_GROUP_get_degree(EC_KEY_get0_group(ec_key))) {
 		GMAPIerr(GMAPI_F_EC_KEY_SET_ECCPUBLICKEYBLOB, GMAPI_R_INVALID_KEY_LENGTH);
 		return 0;
 	}
-
+	*/
 	if (!(x = BN_bin2bn(blob->XCoordinate, sizeof(blob->XCoordinate), NULL))) {
 		GMAPIerr(GMAPI_F_EC_KEY_SET_ECCPUBLICKEYBLOB, ERR_R_BN_LIB);
 		goto end;

--- a/ssl/statem/statem_gmtls.c
+++ b/ssl/statem/statem_gmtls.c
@@ -538,7 +538,7 @@ end:
 	}
 	OPENSSL_free(encodedPoint);
 	EVP_MD_CTX_free(md_ctx);
-	OPENSSL_free(id);
+	//OPENSSL_free(id);
 	return ret;
 }
 


### PR DESCRIPTION
Id is a pointer to a global c string now.It is not allocated by any OPENSSL_malloc.This OPENSSL_free(id) could cause a crash