### PR TITLE
fix build on CentOS8/aarch64

### DIFF
--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3129,7 +3129,7 @@ static const ec_list_element curve_list[] = {
      "RFC 5639 curve over a 512 bit prime field"},
 #ifndef OPENSSL_NO_SM2
     {NID_sm2p256v1, &_EC_SM2_PRIME_256V1.h,
-# if defined(ECP_NISTZ256_ASM) && BN_BITS2 == 64 && !defined(GMSSL_NO_TURBO)
+# if ECP_SM2Z256_ASM
      EC_GFp_sm2z256_method,
 # elif !defined(OPENSSL_NO_EC_NISTP_64_GCC_128)
      EC_GFp_sm2p256_method,

--- a/crypto/ec/ec_lcl.h
+++ b/crypto/ec/ec_lcl.h
@@ -578,7 +578,7 @@ const EC_METHOD *EC_GFp_nistz256_method(void);
 #endif
 
 #ifndef OPENSSL_NO_SM2
-# if defined(ECP_NISTZ256_ASM) && BN_BITS2 == 64 && !defined(GMSSL_NO_TURBO)
+# if ECP_SM2Z256_ASM
 const EC_METHOD *EC_GFp_sm2z256_method(void);
 # endif
 #endif

--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -107,7 +107,7 @@ static ossl_inline int io_setup(unsigned n, aio_context_t *ctx)
 
 static ossl_inline int eventfd(int n)
 {
-    return syscall(__NR_eventfd, n);
+    return syscall(__NR_eventfd2, n, 0);
 }
 
 static ossl_inline int io_destroy(aio_context_t ctx)


### PR DESCRIPTION
eventfd() system call is DEPRECATED, use eventfd2() instead!!!
There is no crypto/ec/asm/ecp_sm2z256-armv8.pl  for aarch64