### PR TITLE
fix build on aarch64 w/ CentOS 8.2

### DIFF
--- a/Configure
+++ b/Configure
@@ -1243,6 +1243,9 @@ unless ($disabled{asm}) {
     if ($target{ec_asm_src} =~ /ecp_nistz256/) {
 	push @{$config{defines}}, "ECP_NISTZ256_ASM";
     }
+    if ($target{ec_asm_src} =~ /ecp_sm2z256/) {
+	push @{$config{defines}}, "ECP_SM2Z256_ASM";
+    }
     if ($target{padlock_asm_src} ne $table{DEFAULTS}->{padlock_asm_src}) {
 	push @{$config{defines}}, "PADLOCK_ASM";
     }

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3129,7 +3129,7 @@ static const ec_list_element curve_list[] = {
      "RFC 5639 curve over a 512 bit prime field"},
 #ifndef OPENSSL_NO_SM2
     {NID_sm2p256v1, &_EC_SM2_PRIME_256V1.h,
-# if defined(ECP_NISTZ256_ASM) && BN_BITS2 == 64 && !defined(GMSSL_NO_TURBO)
+#if defined(ECP_SM2Z256_ASM) && BN_BITS2 == 64 && !defined(GMSSL_NO_TURBO)
      EC_GFp_sm2z256_method,
 # elif !defined(OPENSSL_NO_EC_NISTP_64_GCC_128)
      EC_GFp_sm2p256_method,

--- a/crypto/ec/ec_lcl.h
+++ b/crypto/ec/ec_lcl.h
@@ -242,7 +242,7 @@ struct ec_group_st {
         PCT_none,
         PCT_nistp224, PCT_nistp256, PCT_nistp521, PCT_nistz256,
         PCT_sm2p256,
-	PCT_sm2z256,
+        PCT_sm2z256,
         PCT_ec
     } pre_comp_type;
     union {
@@ -578,7 +578,7 @@ const EC_METHOD *EC_GFp_nistz256_method(void);
 #endif
 
 #ifndef OPENSSL_NO_SM2
-# if defined(ECP_NISTZ256_ASM) && BN_BITS2 == 64 && !defined(GMSSL_NO_TURBO)
+# if defined(ECP_SM2Z256_ASM) && BN_BITS2 == 64 && !defined(GMSSL_NO_TURBO)
 const EC_METHOD *EC_GFp_sm2z256_method(void);
 # endif
 #endif

--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -107,7 +107,7 @@ static ossl_inline int io_setup(unsigned n, aio_context_t *ctx)
 
 static ossl_inline int eventfd(int n)
 {
-    return syscall(__NR_eventfd, n);
+    return syscall(__NR_eventfd2, n, 0);
 }
 
 static ossl_inline int io_destroy(aio_context_t ctx)


### PR DESCRIPTION
There's no sm2z256 asm for aarch64/arm64
eventfd() system call is DEPRECATED, use eventfd2() instead!!!