### PR TITLE
fix GMTLS construct client verify bug

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2772,7 +2772,12 @@ int tls_construct_client_verify(SSL *s)
     }
 
     p = ssl_handshake_start(s);
-    pkey = s->cert->key->privatekey;
+#ifndef OPENSSL_NO_GMTLS
+    if (SSL_IS_GMTLS(s))
+        pkey = s->cert->pkeys[SSL_PKEY_SM2].privatekey;
+    else
+#endif
+        pkey = s->cert->key->privatekey;
 
     hdatalen = BIO_get_mem_data(s->s3->handshake_buffer, &hdata);
     if (hdatalen <= 0) {


### PR DESCRIPTION
If client has both sign and encryption privatekey, the s->cert->key->privatekey maybe points to encryption privatekey(this will happen when client set sign privatekey before setting encryption privatekey).In that case, client will use encryption privatekey to create a signature for "GMTLS construct client verify"