### PR TITLE
国密协议使用签名证书对应的密钥生成 CertificateVerify

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2773,6 +2773,10 @@ int tls_construct_client_verify(SSL *s)
 
     p = ssl_handshake_start(s);
     pkey = s->cert->key->privatekey;
+  
+    if (s->version == 0x0101) {
+        pkey = s->cert->pkeys[SSL_PKEY_SM2].privatekey;
+    }
 
     hdatalen = BIO_get_mem_data(s->s3->handshake_buffer, &hdata);
     if (hdatalen <= 0) {


### PR DESCRIPTION
CertificateVerify 消息使用签名证书对应的密钥签名，而不是 SSL_CTX_use_PrivateKey_file() 最后一次调用加入的密钥。