### PR TITLE
解决client端证书交换数据包构造问题

### DIFF
--- a/ssl/statem/statem_gmtls.c
+++ b/ssl/statem/statem_gmtls.c
@@ -141,8 +141,10 @@ static int gmtls_output_cert_chain(SSL *s, int *len, int a_idx, int k_idx)
 			return 0;
 		}
 		/* add key exchange certificate */
-		if (!ssl_add_cert_to_buf(buf, &l, s->cert->pkeys[k_idx].x509)) {
-			return 0;
+		if(s->cert->pkeys[k_idx].x509 != NULL){
+			if (!ssl_add_cert_to_buf(buf, &l, s->cert->pkeys[k_idx].x509)) {
+				return 0;
+			}
 		}
 		/* add the following chain */
 		for (i = 1; i < sk_X509_num(chain); i++) {


### PR DESCRIPTION
解决client端证书交换数据包构造问题
之前版本发送的Certificate用Wireshark抓包能发现异常情况，有证书长度为0。看起来不应该出现长度为0的证书。对这种情况进行了跳过