### PR TITLE
SDF/SKF: Fix compilation on Windows

### DIFF
--- a/crypto/gmapi/gmapi_sgd.c
+++ b/crypto/gmapi/gmapi_sgd.c
@@ -47,13 +47,13 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <stdio.h>
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/sgd.h>
 #include <openssl/gmapi.h>
-#include "../../e_os.h"
 
 typedef struct {
 	int nid;

--- a/crypto/sdf/sdf_ext.c
+++ b/crypto/sdf/sdf_ext.c
@@ -47,11 +47,11 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/gmsdf.h>
 #include "internal/sdf_int.h"
-#include "../../e_os.h"
 #include "sdf_sansec.h"
 
 

--- a/crypto/sdf/sdf_lib.c
+++ b/crypto/sdf/sdf_lib.c
@@ -47,11 +47,11 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/gmsdf.h>
 #include "internal/sdf_int.h"
-#include "../../e_os.h"
 
 SDF_METHOD *sdf_method = NULL;
 SDF_VENDOR *sdf_vendor = NULL;

--- a/crypto/sdf/sdf_sansec.c
+++ b/crypto/sdf/sdf_sansec.c
@@ -47,11 +47,11 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/gmsdf.h>
 #include "internal/sdf_int.h"
-#include "../../e_os.h"
 #include "sdf_sansec.h"
 
 typedef struct {

--- a/crypto/skf/skf_ext.c
+++ b/crypto/skf/skf_ext.c
@@ -47,6 +47,7 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -57,7 +58,6 @@
 #include <openssl/gmapi.h>
 #include <openssl/x509v3.h>
 #include "internal/skf_int.h"
-#include "../../e_os.h"
 
 
 ULONG DEVAPI SKF_NewECCCipher(ULONG ulCipherLen, ECCCIPHERBLOB **cipherBlob)

--- a/crypto/skf/skf_lib.c
+++ b/crypto/skf/skf_lib.c
@@ -47,6 +47,7 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -54,7 +55,6 @@
 #include <openssl/gmskf.h>
 #include "internal/dso.h"
 #include "internal/skf_int.h"
-#include "../../e_os.h"
 
 
 SKF_METHOD *skf_method = NULL;

--- a/crypto/skf/skf_prn.c
+++ b/crypto/skf/skf_prn.c
@@ -47,6 +47,7 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -54,7 +55,6 @@
 #include <openssl/err.h>
 #include <openssl/gmskf.h>
 #include "internal/skf_int.h"
-#include "../../e_os.h"
 
 
 static char *skf_algor_name(ULONG ulAlgID)

--- a/crypto/skf/skf_wisec.c
+++ b/crypto/skf/skf_wisec.c
@@ -47,10 +47,10 @@
  * ====================================================================
  */
 
+#include "../../e_os.h"
 #include <openssl/err.h>
 #include <openssl/gmskf.h>
 #include "internal/skf_int.h"
-#include "../../e_os.h"
 #include "skf_wisec.h"
 
 typedef struct {

--- a/include/openssl/sgd.h
+++ b/include/openssl/sgd.h
@@ -342,32 +342,7 @@ typedef UINT32			FLAGS;
 typedef CHAR *			LPSTR;
 typedef void *			HANDLE;
 #else
-#ifndef _WINDEF_H
-typedef signed char		INT8;
-typedef signed short		INT16;
-typedef signed int		INT32;
-typedef unsigned char		UINT8;
-typedef unsigned short		UINT16;
-typedef unsigned int		UINT32;
-typedef long			BOOL;
-typedef UINT8			BYTE;
-typedef UINT8			CHAR;
-typedef INT16			SHORT;
-typedef UINT16			USHORT;
-# ifndef SGD_NATIVE_LONG
-typedef INT32			LONG;
-typedef UINT32			ULONG;
-# else
-typedef long			LONG;
-typedef unsigned long		ULONG;
-# endif
-typedef UINT32			UINT;
-typedef UINT16			WORD;
-typedef UINT32			DWORD;
-typedef UINT32			FLAGS;
-typedef CHAR *			LPSTR;
-typedef void *			HANDLE;
-#endif
+#include <windef.h>
 #endif
 
 typedef HANDLE DEVHANDLE;


### PR DESCRIPTION
`e_os.h` includes windef.h *after* `ULONG` and friends are already defined
by sgd.h, and the definition is different.

Solve by including `e_os.h` first, and in case `sgd.h` is included first,
include `windef.h` instead of manually defining all the types.