### PR TITLE
fixs ERR_error_string crash

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -564,18 +564,14 @@ void ERR_error_string_n(unsigned long e, char *buf, size_t len)
 }
 
 /*
- * ERR_error_string_n should be used instead for ret != NULL as
  * ERR_error_string cannot know how large the buffer is
  */
-char *ERR_error_string(unsigned long e, char *ret)
+char *ERR_error_string(unsigned long e)
 {
     static char buf[256];
+    ERR_error_string_n(e, buf, sizeof(buf));
 
-    if (ret == NULL)
-        ret = buf;
-    ERR_error_string_n(e, ret, 256);
-
-    return ret;
+    return buf;
 }
 
 const char *ERR_lib_error_string(unsigned long e)

--- a/doc/crypto/ERR_error_string.pod
+++ b/doc/crypto/ERR_error_string.pod
@@ -12,7 +12,7 @@ error message
 
  #include <openssl/err.h>
 
- char *ERR_error_string(unsigned long e, char *buf);
+ char *ERR_error_string(unsigned long e);
  void ERR_error_string_n(unsigned long e, char *buf, size_t len);
 
  const char *ERR_lib_error_string(unsigned long e);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -246,7 +246,7 @@ unsigned long ERR_peek_last_error_line(const char **file, int *line);
 unsigned long ERR_peek_last_error_line_data(const char **file, int *line,
                                             const char **data, int *flags);
 void ERR_clear_error(void);
-char *ERR_error_string(unsigned long e, char *buf);
+char *ERR_error_string(unsigned long e);
 void ERR_error_string_n(unsigned long e, char *buf, size_t len);
 const char *ERR_lib_error_string(unsigned long e);
 const char *ERR_func_error_string(unsigned long e);


### PR DESCRIPTION
when ret==NULL be assigned will crash. ERR_error_string only provides a recommended cache size to store error information. The cache size should not be passed in. If you need a specific cache to store error information, you can use ERR_error_string_n