### PR TITLE
GMTLSv1.1 support session id resumption

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -630,10 +630,11 @@ int ssl_get_prev_session(SSL *s, const PACKET *ext, const PACKET *session_id)
         p = buf;
         l = ret->cipher_id;
         l2n(l, p);
-        if ((ret->ssl_version >> 8) >= SSL3_VERSION_MAJOR)
+        if ((ret->ssl_version >> 8) >= SSL3_VERSION_MAJOR || ret->ssl_version == GMTLS_VERSION) {
             ret->cipher = ssl_get_cipher_by_char(s, &(buf[2]));
-        else
+        } else {
             ret->cipher = ssl_get_cipher_by_char(s, &(buf[1]));
+        }
         if (ret->cipher == NULL)
             goto err;
     }


### PR DESCRIPTION
Nginx集成GmSSL库支持gmtls协议，发现客户端在和nginx进行gmtls握手时，nginx作为服务端每次握手会回复不同的session id，导致基于session id的会话恢复不生效。修复gmtls协议session id的会话恢复不生效问题。