### PR TITLE
Add compilation support for loongarch64 arch

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -736,6 +736,13 @@ sub vms_info {
         shared_ldflag    => add("-mabi=64"),
         multilib         => "64",
     },
+    "linux64-loongarch64" => {
+        inherit_from     => [ "linux-generic64" ],
+        cflags           => add("-mabi=lp64"),
+        perlasm_scheme   => "64",
+        shared_ldflag    => add("-mabi=lp64"),
+        multilib         => "64",
+    },
 
     #### IA-32 targets...
     #### These two targets are a bit aged and are to be used on older Linux

--- a/config
+++ b/config
@@ -565,6 +565,7 @@ case "$GUESSOS" in
 	OUT="linux-mips64"
 	;;
   mips*-*-linux2) OUT="linux-mips32" ;;
+  loongarch64-*-linux2) OUT="linux64-loongarch64" ;;
   ppc60x-*-vxworks*) OUT="vxworks-ppc60x" ;;
   ppcgen-*-vxworks*) OUT="vxworks-ppcgen" ;;
   pentium-*-vxworks*) OUT="vxworks-pentium" ;;

--- a/engines/afalg/e_afalg.c
+++ b/engines/afalg/e_afalg.c
@@ -105,9 +105,14 @@ static ossl_inline int io_setup(unsigned n, aio_context_t *ctx)
     return syscall(__NR_io_setup, n, ctx);
 }
 
+/* Add __NR_eventfd2 syscall for loongarch64 architecture */
 static ossl_inline int eventfd(int n)
 {
+#ifdef __loongarch64
+    return syscall(__NR_eventfd2, n);
+#else	
     return syscall(__NR_eventfd, n);
+#endif    
 }
 
 static ossl_inline int io_destroy(aio_context_t ctx)


### PR DESCRIPTION
Add compilation support for loongarch64 arch.

Reference link:http://gmssl.org/docs/quickstart.html
test version on loongarch64 arch:
root@loongson-pc:/usr/local/gmssl# gmssl version
GmSSL 2.5.4 - OpenSSL 1.1.0d  19 Jun 2019
Tests are normal，like test SM4、SM3、SM2 and so on.
Examples：
root@loongson-pc:/usr/local/gmssl# lscpu |grep Architecture
Architecture:        loongarch64
root@loongson-pc:/usr/local/ssl-test# gmssl sms4 -e -in test.txt -out test.txt.sms4
enter sms4-cbc encryption password:
Verifying - enter sms4-cbc encryption password:
root@loongson-pc:/usr/local/ssl-test# ls
test.txt  test.txt.sms4
root@loongson-pc:/usr/local/ssl-test# gmssl sms4 -d -in test.txt.sms4 
enter sms4-cbc decryption password:
111111111111123333333333333333455555555555555555555
root@loongson-pc:/usr/local/ssl-test# gmssl sm3 test.txt
SM3(test.txt)= 4ec58d59296b4487df4d7290f445ecfd52f2b238f4feb3bf437a0b01db5871a7

