### PR TITLE
fix: extern "C" right brace

### DIFF
--- a/include/gmssl/sm2.h
+++ b/include/gmssl/sm2.h
@@ -369,6 +369,6 @@ int sm2_ecdh(const SM2_KEY *key, const SM2_POINT *peer_public, SM2_POINT *out);
 
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 #endif


### PR DESCRIPTION
本地使用时，在 C++ 项目内引入 `sm2.h` 后报错

看起来是最后的右括号错误