### PR TITLE
Fix a segfault for test case #6 (cms)

### DIFF
--- a/tests/cmstest.c
+++ b/tests/cmstest.c
@@ -329,7 +329,7 @@ static int test_cms_signer_info(void)
 	size_t issuer_len;
 	uint8_t serial_buf[20];
 	uint8_t sig_buf[256];
-	size_t siglen;
+	size_t siglen = sizeof(sig_buf);
 
 	int version;
 	const uint8_t *issuer;


### PR DESCRIPTION
In test case 6 on develop branch, the `siglen` in `test_cms_signer_info()` do not initialize, which makes a segfault. This pull request fixes this by initializing the `siglen` to length of `sig_buf`.