### PR TITLE
修复JNI接口中SM4解密内存管理缺陷

### DIFF
--- a/java/GmSSL.c
+++ b/java/GmSSL.c
@@ -424,6 +424,7 @@ end:
 	if (keybuf) (*env)->ReleaseByteArrayElements(env, key, (jbyte *)keybuf, JNI_ABORT);
 	if (inbuf) (*env)->ReleaseByteArrayElements(env, in, (jbyte *)inbuf, JNI_ABORT);
 	if (ivbuf) (*env)->ReleaseByteArrayElements(env, iv, (jbyte *)ivbuf, JNI_ABORT);
+	OPENSSL_free(outbuf);
 	EVP_CIPHER_CTX_free(cctx);
 	return ret;
 }


### PR DESCRIPTION
SM4接口在JNI的封装方法Java_org_gmssl_GmSSL_symmetricEncrypt中outbuf指针的内存未释放，会造成Java应用内存耗尽。
经压测环境验证，在GmSSL/java/GmSSL.c文件补充以下代码可解决内存消耗的问题：
OPENSSL_free(outbuf);