### PR TITLE
Fix perl build issues

### DIFF
--- a/Configure
+++ b/Configure
@@ -15,7 +15,9 @@ use strict;
 use File::Basename;
 use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs/;
 use File::Path qw/mkpath/;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin/util/perl";
+use OpenSSL::Glob;
 
 # see INSTALL for instructions.
 

--- a/test/build.info
+++ b/test/build.info
@@ -336,8 +336,10 @@ ENDIF
 {-
    use File::Spec::Functions;
    use File::Basename;
-   use if $^O ne "VMS", 'File::Glob' => qw/glob/;
-
+   use FindBin;
+   use lib "$FindBin::Bin/util/perl";
+   use OpenSSL::Glob;
+   
    my @nogo_headers = ( "asn1_mac.h",
                         "__decc_include_prologue.h",
                         "__decc_include_epilogue.h" );

--- a/test/recipes/40-test_rehash.t
+++ b/test/recipes/40-test_rehash.t
@@ -13,7 +13,9 @@ use warnings;
 use File::Spec::Functions;
 use File::Copy;
 use File::Basename;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin/util/perl";
+use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT bldtop_file/;
 
 setup("test_rehash");

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -12,7 +12,9 @@ use warnings;
 
 use File::Basename;
 use File::Compare qw/compare_text/;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin/util/perl";
+use OpenSSL::Glob;
 
 use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file/;
 use OpenSSL::Test::Utils qw/disabled alldisabled available_protocols/;

--- a/test/recipes/90-test_fuzz.t
+++ b/test/recipes/90-test_fuzz.t
@@ -9,7 +9,9 @@
 use strict;
 use warnings;
 
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin/util/perl";
+use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT srctop_file/;
 use OpenSSL::Test::Utils;
 

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -16,7 +16,9 @@ BEGIN {
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
 use File::Basename;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin/util/perl";
+use OpenSSL::Glob;
 use Test::Harness qw/runtests $switches/;
 
 my $srctop = $ENV{SRCTOP} || $ENV{TOP};

--- a/util/perl/OpenSSL/Glob.pm
+++ b/util/perl/OpenSSL/Glob.pm
@@ -1,0 +1,21 @@
+package OpenSSL::Glob;
+
+use strict;
+use warnings;
+
+use File::Glob;
+
+use Exporter;
+use vars qw($VERSION @ISA @EXPORT);
+
+$VERSION = '0.1';
+@ISA = qw(Exporter);
+@EXPORT = qw(glob);
+
+sub glob {
+    goto &File::Glob::bsd_glob if $^O ne "VMS";
+    goto &CORE::glob;
+}
+
+1;
+__END__

--- a/util/process_docs.pl
+++ b/util/process_docs.pl
@@ -13,7 +13,9 @@ use File::Spec::Functions;
 use File::Basename;
 use File::Copy;
 use File::Path;
-use if $^O ne "VMS", 'File::Glob' => qw/glob/;
+use FindBin;
+use lib "$FindBin::Bin/util/perl";
+use OpenSSL::Glob;
 use Getopt::Long;
 use Pod::Usage;
 


### PR DESCRIPTION
Hello,

I was attempting to build GmSSL and I noticed the build was failing on a perl Glob call. After Perl 5.30, File::Glob no longer exports glob. Since it's similar to OpenSSL, I reviewed their changes to work with Perl 5.30+ and have applied the same changes to GmSSL.  I verified the build now works.

Lance