### PR TITLE
fix duplicate symbol with openssl

### DIFF
--- a/demos/sm2/sm2_encrypt_demo.c
+++ b/demos/sm2/sm2_encrypt_demo.c
@@ -25,10 +25,10 @@ int main(void)
 	sm2_key_generate(&sm2_key);
 	memcpy(&pub_key, &sm2_key, sizeof(SM2_POINT));
 
-	sm2_encrypt(&pub_key, (uint8_t *)"hello world", strlen("hello world"), ciphertext, &len);
+	GMSSL_sm2_encrypt(&pub_key, (uint8_t *)"hello world", strlen("hello world"), ciphertext, &len);
 	format_bytes(stdout, 0, 0, "ciphertext", ciphertext, len);
 
-	if (sm2_decrypt(&sm2_key, ciphertext, len, plaintext, &len) != 1) {
+	if (GMSSL_sm2_decrypt(&sm2_key, ciphertext, len, plaintext, &len) != 1) {
 		fprintf(stderr, "error\n");
 		return 1;
 	}

--- a/demos/sm2/sm2_sign_ctx_demo.c
+++ b/demos/sm2/sm2_sign_ctx_demo.c
@@ -37,7 +37,7 @@ int main(void)
 
 	// digest and verify
 	sm3_digest((unsigned char *)"hello world", strlen("hello world"), dgst);
-	ret = sm2_verify(&pub_key, dgst, sig, siglen);
+	ret = GMSSL_sm2_verify(&pub_key, dgst, sig, siglen);
 	printf("verify result: %s\n", ret == 1 ? "success" : "failure");
 
 	// use verify update API

--- a/demos/sm2/sm2_sign_demo.c
+++ b/demos/sm2/sm2_sign_demo.c
@@ -28,12 +28,12 @@ int main(void)
 
 	sm2_key_generate(&sm2_key);
 
-	sm2_sign(&sm2_key, dgst, sig, &siglen);
+	GMSSL_sm2_sign(&sm2_key, dgst, sig, &siglen);
 	format_bytes(stdout, 0, 0, "signature", sig, siglen);
 
 	memcpy(&pub_key, &sm2_key, sizeof(SM2_POINT));
 
-	if ((ret = sm2_verify(&pub_key, dgst, sig, siglen)) != 1) {
+	if ((ret = GMSSL_sm2_verify(&pub_key, dgst, sig, siglen)) != 1) {
 		fprintf(stderr, "verify failed\n");
 	} else {
 		printf("verify success\n");

--- a/demos/sm3/sm3_demo.c
+++ b/demos/sm3/sm3_demo.c
@@ -22,9 +22,9 @@ int main(int argc, char **argv)
 	uint8_t dgst[32];
 	int i;
 
-	sm3_init(&sm3_ctx);
+	GMSSL_sm3_init(&sm3_ctx);
 	while ((len = fread(buf, 1, sizeof(buf), stdin)) > 0) {
-		sm3_update(&sm3_ctx, buf, len);
+		GMSSL_sm3_update(&sm3_ctx, buf, len);
 	}
 	sm3_finish(&sm3_ctx, dgst);
 

--- a/include/gmssl/sm2.h
+++ b/include/gmssl/sm2.h
@@ -42,10 +42,10 @@ SM2 Public API
 	sm2_public_key_info_to_pem
 	sm2_public_key_info_from_pem
 
-	sm2_sign
-	sm2_verify
-	sm2_encrypt
-	sm2_decrypt
+	GMSSL_sm2_sign
+	GMSSL_sm2_verify
+	GMSSL_sm2_encrypt
+	GMSSL_sm2_decrypt
 	sm2_ecdh
 
 	SM2_SIGN_CTX
@@ -299,8 +299,8 @@ typedef struct {
 } SM2_SIGNATURE;
 
 int sm2_do_sign_ex(const SM2_KEY *key, int flags, const uint8_t dgst[32], SM2_SIGNATURE *sig);
-int sm2_do_sign(const SM2_KEY *key, const uint8_t dgst[32], SM2_SIGNATURE *sig);
-int sm2_do_verify(const SM2_KEY *key, const uint8_t dgst[32], const SM2_SIGNATURE *sig);
+int GMSSL_sm2_do_sign(const SM2_KEY *key, const uint8_t dgst[32], SM2_SIGNATURE *sig);
+int GMSSL_sm2_do_verify(const SM2_KEY *key, const uint8_t dgst[32], const SM2_SIGNATURE *sig);
 
 #define SM2_MIN_SIGNATURE_SIZE 8
 #define SM2_MAX_SIGNATURE_SIZE 72
@@ -308,8 +308,8 @@ int sm2_signature_to_der(const SM2_SIGNATURE *sig, uint8_t **out, size_t *outlen
 int sm2_signature_from_der(SM2_SIGNATURE *sig, const uint8_t **in, size_t *inlen);
 int sm2_signature_print(FILE *fp, int fmt, int ind, const char *label, const uint8_t *sig, size_t siglen);
 int sm2_sign_ex(const SM2_KEY *key, int flags, const uint8_t dgst[32], uint8_t *sig, size_t *siglen);
-int sm2_sign(const SM2_KEY *key, const uint8_t dgst[32], uint8_t *sig, size_t *siglen);
-int sm2_verify(const SM2_KEY *key, const uint8_t dgst[32], const uint8_t *sig, size_t siglen);
+int GMSSL_sm2_sign(const SM2_KEY *key, const uint8_t dgst[32], uint8_t *sig, size_t *siglen);
+int GMSSL_sm2_verify(const SM2_KEY *key, const uint8_t dgst[32], const uint8_t *sig, size_t siglen);
 
 
 #define SM2_DEFAULT_ID		"1234567812345678"
@@ -361,8 +361,8 @@ int sm2_ciphertext_to_der(const SM2_CIPHERTEXT *c, uint8_t **out, size_t *outlen
 int sm2_ciphertext_from_der(SM2_CIPHERTEXT *c, const uint8_t **in, size_t *inlen);
 int sm2_ciphertext_print(FILE *fp, int fmt, int ind, const char *label, const uint8_t *a, size_t alen);
 int sm2_encrypt_ex(const SM2_KEY *key, int flags, const uint8_t *in, size_t inlen, uint8_t *out, size_t *outlen);
-int sm2_encrypt(const SM2_KEY *key, const uint8_t *in, size_t inlen, uint8_t *out, size_t *outlen);
-int sm2_decrypt(const SM2_KEY *key, const uint8_t *in, size_t inlen, uint8_t *out, size_t *outlen);
+int GMSSL_sm2_encrypt(const SM2_KEY *key, const uint8_t *in, size_t inlen, uint8_t *out, size_t *outlen);
+int GMSSL_sm2_decrypt(const SM2_KEY *key, const uint8_t *in, size_t inlen, uint8_t *out, size_t *outlen);
 
 
 int sm2_ecdh(const SM2_KEY *key, const SM2_POINT *peer_public, SM2_POINT *out);

--- a/include/gmssl/sm3.h
+++ b/include/gmssl/sm3.h
@@ -25,8 +25,8 @@ SM3 Public API
 	SM3_HMAC_SIZE
 
 	SM3_CTX
-	sm3_init
-	sm3_update
+	GMSSL_sm3_init
+	GMSSL_sm3_update
 	sm3_finish
 
 	SM3_HMAC_CTX
@@ -53,8 +53,8 @@ typedef struct {
 	size_t num;
 } SM3_CTX;
 
-void sm3_init(SM3_CTX *ctx);
-void sm3_update(SM3_CTX *ctx, const uint8_t *data, size_t datalen);
+void GMSSL_sm3_init(SM3_CTX *ctx);
+void GMSSL_sm3_update(SM3_CTX *ctx, const uint8_t *data, size_t datalen);
 void sm3_finish(SM3_CTX *ctx, uint8_t dgst[SM3_DIGEST_SIZE]);
 void sm3_digest(const uint8_t *data, size_t datalen, uint8_t dgst[SM3_DIGEST_SIZE]);
 

--- a/src/cms.c
+++ b/src/cms.c
@@ -749,7 +749,7 @@ int cms_signer_info_sign_to_der(
 	uint8_t sig[SM2_MAX_SIGNATURE_SIZE];
 	size_t siglen;
 
-	sm3_update(&ctx, authed_attrs, authed_attrs_len);
+	GMSSL_sm3_update(&ctx, authed_attrs, authed_attrs_len);
 	sm3_finish(&ctx, dgst);
 
 
@@ -807,10 +807,10 @@ int cms_signer_info_verify_from_der(
 		return -1;
 	}
 
-	sm3_update(&sm3_ctx, *authed_attrs, *authed_attrs_len);
+	GMSSL_sm3_update(&sm3_ctx, *authed_attrs, *authed_attrs_len);
 	sm3_finish(&sm3_ctx, dgst);
 
-	if (sm2_verify(&public_key, dgst, sig, siglen) != 1) {
+	if (GMSSL_sm2_verify(&public_key, dgst, sig, siglen) != 1) {
 		error_print();
 		return -1;
 	}
@@ -1089,9 +1089,9 @@ int cms_signed_data_sign_to_der(
 		}
 	}
 
-	sm3_init(&sm3_ctx);
-	sm3_update(&sm3_ctx, content_header, content_header_len);
-	sm3_update(&sm3_ctx, data, datalen);
+	GMSSL_sm3_init(&sm3_ctx);
+	GMSSL_sm3_update(&sm3_ctx, content_header, content_header_len);
+	GMSSL_sm3_update(&sm3_ctx, data, datalen);
 
 	for (i = 0; i < signers_cnt; i++) {
 		if (x509_cert_get_issuer_and_serial_number(
@@ -1168,10 +1168,10 @@ int cms_signed_data_verify_from_der(
 		error_print();
 		return -1;
 	}
-	sm3_init(&sm3_ctx);
+	GMSSL_sm3_init(&sm3_ctx);
 
-	sm3_update(&sm3_ctx, content_info_header, content_info_header_len);
-	sm3_update(&sm3_ctx, *content, *content_len);
+	GMSSL_sm3_update(&sm3_ctx, content_info_header, content_info_header_len);
+	GMSSL_sm3_update(&sm3_ctx, *content, *content_len);
 
 	while (signer_infos_len) {
 		const uint8_t *cert;
@@ -1366,7 +1366,7 @@ int cms_recipient_info_decrypt_from_der(
 		error_print();
 		return -1;
 	}
-	if (sm2_decrypt(sm2_key, enced_key, enced_key_len, outbuf, outlen) != 1) {
+	if (GMSSL_sm2_decrypt(sm2_key, enced_key, enced_key_len, outbuf, outlen) != 1) {
 		error_print();
 		return -1;
 	}
@@ -1792,9 +1792,9 @@ int cms_signed_and_enveloped_data_encipher_to_der(
 		error_print();
 		return -1;
 	}
-	sm3_init(&sm3_ctx);
-	sm3_update(&sm3_ctx, content_info_header, content_info_header_len);
-	sm3_update(&sm3_ctx, content, content_len);
+	GMSSL_sm3_init(&sm3_ctx);
+	GMSSL_sm3_update(&sm3_ctx, content_info_header, content_info_header_len);
+	GMSSL_sm3_update(&sm3_ctx, content, content_len);
 
 	for (i = 0; i < signers_cnt; i++) {
 		if (x509_cert_get_issuer_and_serial_number(
@@ -1927,9 +1927,9 @@ int cms_signed_and_enveloped_data_decipher_from_der(
 		error_print();
 		return -1;
 	}
-	sm3_init(&sm3_ctx);
-	sm3_update(&sm3_ctx, content_info_header, content_info_header_len);
-	sm3_update(&sm3_ctx, content, *content_len);
+	GMSSL_sm3_init(&sm3_ctx);
+	GMSSL_sm3_update(&sm3_ctx, content_info_header, content_info_header_len);
+	GMSSL_sm3_update(&sm3_ctx, content, *content_len);
 
 	while (signer_infos_len) {
 		const uint8_t *cert;

--- a/src/digest.c
+++ b/src/digest.c
@@ -123,7 +123,7 @@ static int sm3_digest_init(DIGEST_CTX *ctx)
 		error_print();
 		return -1;
 	}
-	sm3_init(&ctx->u.sm3_ctx);
+	GMSSL_sm3_init(&ctx->u.sm3_ctx);
 	return 1;
 }
 
@@ -133,7 +133,7 @@ static int sm3_digest_update(DIGEST_CTX *ctx, const uint8_t *in, size_t inlen)
 		error_print();
 		return -1;
 	}
-	sm3_update(&ctx->u.sm3_ctx, in, inlen);
+	GMSSL_sm3_update(&ctx->u.sm3_ctx, in, inlen);
 	return 1;
 }
 

--- a/src/hex.c
+++ b/src/hex.c
@@ -15,7 +15,7 @@
 #include <stdint.h>
 #include <gmssl/error.h>
 
-int OPENSSL_hexchar2int(unsigned char c)
+int OPSSL_hexchar2int(unsigned char c)
 {
     switch (c) {
     case '0':
@@ -55,7 +55,7 @@ int OPENSSL_hexchar2int(unsigned char c)
     return -1;
 }
 
-unsigned char *OPENSSL_hexstr2buf(const char *str, size_t *len)
+unsigned char *hexstr2buf(const char *str, size_t *len)
 {
     unsigned char *hexbuf, *q;
     unsigned char ch, cl;
@@ -77,8 +77,8 @@ unsigned char *OPENSSL_hexstr2buf(const char *str, size_t *len)
             free(hexbuf);
             return NULL;
         }
-        cli = OPENSSL_hexchar2int(cl);
-        chi = OPENSSL_hexchar2int(ch);
+        cli = OPSSL_hexchar2int(cl);
+        chi = OPSSL_hexchar2int(ch);
         if (cli < 0 || chi < 0) {
             free(hexbuf);
             //CRYPTOerr(CRYPTO_F_OPENSSL_HEXSTR2BUF, CRYPTO_R_ILLEGAL_HEX_DIGIT);

--- a/src/sm3.c
+++ b/src/sm3.c
@@ -295,7 +295,7 @@ void sm3_compress_blocks(uint32_t digest[8], const uint8_t *data, size_t blocks)
 }
 
 
-void sm3_init(SM3_CTX *ctx)
+void GMSSL_sm3_init(SM3_CTX *ctx)
 {
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->digest[0] = 0x7380166F;
@@ -308,7 +308,7 @@ void sm3_init(SM3_CTX *ctx)
 	ctx->digest[7] = 0xB0FB0E4E;
 }
 
-void sm3_update(SM3_CTX *ctx, const uint8_t *data, size_t data_len)
+void GMSSL_sm3_update(SM3_CTX *ctx, const uint8_t *data, size_t data_len)
 {
 	size_t blocks;
 
@@ -371,7 +371,7 @@ void sm3_digest(const uint8_t *msg, size_t msglen,
 	uint8_t dgst[SM3_DIGEST_SIZE])
 {
 	SM3_CTX ctx;
-	sm3_init(&ctx);
-	sm3_update(&ctx, msg, msglen);
+	GMSSL_sm3_init(&ctx);
+	GMSSL_sm3_update(&ctx, msg, msglen);
 	sm3_finish(&ctx, dgst);
 }

--- a/src/sm3_hmac.c
+++ b/src/sm3_hmac.c
@@ -42,8 +42,8 @@ void sm3_hmac_init(SM3_HMAC_CTX *ctx, const uint8_t *key, size_t key_len)
 		memcpy(ctx->key, key, key_len);
 		memset(ctx->key + key_len, 0, SM3_BLOCK_SIZE - key_len);
 	} else {
-		sm3_init(&ctx->sm3_ctx);
-		sm3_update(&ctx->sm3_ctx, key, key_len);
+		GMSSL_sm3_init(&ctx->sm3_ctx);
+		GMSSL_sm3_update(&ctx->sm3_ctx, key, key_len);
 		sm3_finish(&ctx->sm3_ctx, ctx->key);
 		memset(ctx->key + SM3_DIGEST_SIZE, 0,
 			SM3_BLOCK_SIZE - SM3_DIGEST_SIZE);
@@ -52,13 +52,13 @@ void sm3_hmac_init(SM3_HMAC_CTX *ctx, const uint8_t *key, size_t key_len)
 		ctx->key[i] ^= IPAD;
 	}
 
-	sm3_init(&ctx->sm3_ctx);
-	sm3_update(&ctx->sm3_ctx, ctx->key, SM3_BLOCK_SIZE);
+	GMSSL_sm3_init(&ctx->sm3_ctx);
+	GMSSL_sm3_update(&ctx->sm3_ctx, ctx->key, SM3_BLOCK_SIZE);
 }
 
 void sm3_hmac_update(SM3_HMAC_CTX *ctx, const uint8_t *data, size_t data_len)
 {
-	sm3_update(&ctx->sm3_ctx, data, data_len);
+	GMSSL_sm3_update(&ctx->sm3_ctx, data, data_len);
 }
 
 void sm3_hmac_finish(SM3_HMAC_CTX *ctx, uint8_t mac[SM3_HMAC_SIZE])
@@ -68,9 +68,9 @@ void sm3_hmac_finish(SM3_HMAC_CTX *ctx, uint8_t mac[SM3_HMAC_SIZE])
 		ctx->key[i] ^= (IPAD ^ OPAD);
 	}
 	sm3_finish(&ctx->sm3_ctx, mac);
-	sm3_init(&ctx->sm3_ctx);
-	sm3_update(&ctx->sm3_ctx, ctx->key, SM3_BLOCK_SIZE);
-	sm3_update(&ctx->sm3_ctx, mac, SM3_DIGEST_SIZE);
+	GMSSL_sm3_init(&ctx->sm3_ctx);
+	GMSSL_sm3_update(&ctx->sm3_ctx, ctx->key, SM3_BLOCK_SIZE);
+	GMSSL_sm3_update(&ctx->sm3_ctx, mac, SM3_DIGEST_SIZE);
 	sm3_finish(&ctx->sm3_ctx, mac);
 	memset(ctx, 0, sizeof(*ctx));
 }

--- a/src/sm3_kdf.c
+++ b/src/sm3_kdf.c
@@ -17,13 +17,13 @@
 
 void sm3_kdf_init(SM3_KDF_CTX *ctx, size_t outlen)
 {
-	sm3_init(&ctx->sm3_ctx);
+	GMSSL_sm3_init(&ctx->sm3_ctx);
 	ctx->outlen = outlen;
 }
 
 void sm3_kdf_update(SM3_KDF_CTX *ctx, const uint8_t *data, size_t datalen)
 {
-	sm3_update(&ctx->sm3_ctx, data, datalen);
+	GMSSL_sm3_update(&ctx->sm3_ctx, data, datalen);
 }
 
 void sm3_kdf_finish(SM3_KDF_CTX *ctx, uint8_t *out)
@@ -40,7 +40,7 @@ void sm3_kdf_finish(SM3_KDF_CTX *ctx, uint8_t *out)
 		counter++;
 
 		sm3_ctx = ctx->sm3_ctx;
-		sm3_update(&sm3_ctx, counter_be, sizeof(counter_be));
+		GMSSL_sm3_update(&sm3_ctx, counter_be, sizeof(counter_be));
 		sm3_finish(&sm3_ctx, dgst);
 
 		len = outlen < SM3_DIGEST_SIZE ? outlen : SM3_DIGEST_SIZE;

--- a/src/sm9_key.c
+++ b/src/sm9_key.c
@@ -32,18 +32,18 @@ int sm9_hash1(sm9_bn_t h1, const char *id, size_t idlen, uint8_t hid)
 	uint8_t ct2[4] = {0x00, 0x00, 0x00, 0x02};
 	uint8_t Ha[64];
 
-	sm3_init(&ctx);
-	sm3_update(&ctx, prefix, sizeof(prefix));
-	sm3_update(&ctx, (uint8_t *)id, idlen);
-	sm3_update(&ctx, &hid, 1);
-	sm3_update(&ctx, ct1, sizeof(ct1));
+	GMSSL_sm3_init(&ctx);
+	GMSSL_sm3_update(&ctx, prefix, sizeof(prefix));
+	GMSSL_sm3_update(&ctx, (uint8_t *)id, idlen);
+	GMSSL_sm3_update(&ctx, &hid, 1);
+	GMSSL_sm3_update(&ctx, ct1, sizeof(ct1));
 	sm3_finish(&ctx, Ha);
 
-	sm3_init(&ctx);
-	sm3_update(&ctx, prefix, sizeof(prefix));
-	sm3_update(&ctx, (uint8_t *)id, idlen);
-	sm3_update(&ctx, &hid, 1);
-	sm3_update(&ctx, ct2, sizeof(ct2));
+	GMSSL_sm3_init(&ctx);
+	GMSSL_sm3_update(&ctx, prefix, sizeof(prefix));
+	GMSSL_sm3_update(&ctx, (uint8_t *)id, idlen);
+	GMSSL_sm3_update(&ctx, &hid, 1);
+	GMSSL_sm3_update(&ctx, ct2, sizeof(ct2));
 	sm3_finish(&ctx, Ha + 32);
 
 	sm9_fn_from_hash(h1, Ha);

--- a/src/sm9_lib.c
+++ b/src/sm9_lib.c
@@ -72,14 +72,14 @@ int sm9_signature_from_der(SM9_SIGNATURE *sig, const uint8_t **in, size_t *inlen
 int sm9_sign_init(SM9_SIGN_CTX *ctx)
 {
 	const uint8_t prefix[1] = { SM9_HASH2_PREFIX };
-	sm3_init(&ctx->sm3_ctx);
-	sm3_update(&ctx->sm3_ctx, prefix, sizeof(prefix));
+	GMSSL_sm3_init(&ctx->sm3_ctx);
+	GMSSL_sm3_update(&ctx->sm3_ctx, prefix, sizeof(prefix));
 	return 1;
 }
 
 int sm9_sign_update(SM9_SIGN_CTX *ctx, const uint8_t *data, size_t datalen)
 {
-	sm3_update(&ctx->sm3_ctx, data, datalen);
+	GMSSL_sm3_update(&ctx->sm3_ctx, data, datalen);
 	return 1;
 }
 
@@ -126,11 +126,11 @@ int sm9_do_sign(const SM9_SIGN_KEY *key, const SM3_CTX *sm3_ctx, SM9_SIGNATURE *
 		sm9_fp12_to_bytes(g, wbuf);
 
 		// A4: h = H2(M || w, N)
-		sm3_update(&ctx, wbuf, sizeof(wbuf));
+		GMSSL_sm3_update(&ctx, wbuf, sizeof(wbuf));
 		tmp_ctx = ctx;
-		sm3_update(&ctx, ct1, sizeof(ct1));
+		GMSSL_sm3_update(&ctx, ct1, sizeof(ct1));
 		sm3_finish(&ctx, Ha);
-		sm3_update(&tmp_ctx, ct2, sizeof(ct2));
+		GMSSL_sm3_update(&tmp_ctx, ct2, sizeof(ct2));
 		sm3_finish(&tmp_ctx, Ha + 32);
 		sm9_fn_from_hash(sig->h, Ha);
 
@@ -154,14 +154,14 @@ int sm9_do_sign(const SM9_SIGN_KEY *key, const SM3_CTX *sm3_ctx, SM9_SIGNATURE *
 int sm9_verify_init(SM9_SIGN_CTX *ctx)
 {
 	const uint8_t prefix[1] = { SM9_HASH2_PREFIX };
-	sm3_init(&ctx->sm3_ctx);
-	sm3_update(&ctx->sm3_ctx, prefix, sizeof(prefix));
+	GMSSL_sm3_init(&ctx->sm3_ctx);
+	GMSSL_sm3_update(&ctx->sm3_ctx, prefix, sizeof(prefix));
 	return 1;
 }
 
 int sm9_verify_update(SM9_SIGN_CTX *ctx, const uint8_t *data, size_t datalen)
 {
-	sm3_update(&ctx->sm3_ctx, data, datalen);
+	GMSSL_sm3_update(&ctx->sm3_ctx, data, datalen);
 	return 1;
 }
 
@@ -226,11 +226,11 @@ int sm9_do_verify(const SM9_SIGN_MASTER_KEY *mpk, const char *id, size_t idlen,
 	sm9_fp12_to_bytes(w, wbuf);
 
 	// B9: h2 = H2(M || w, N), check h2 == h
-	sm3_update(&ctx, wbuf, sizeof(wbuf));
+	GMSSL_sm3_update(&ctx, wbuf, sizeof(wbuf));
 	tmp_ctx = ctx;
-	sm3_update(&ctx, ct1, sizeof(ct1));
+	GMSSL_sm3_update(&ctx, ct1, sizeof(ct1));
 	sm3_finish(&ctx, Ha);
-	sm3_update(&tmp_ctx, ct2, sizeof(ct2));
+	GMSSL_sm3_update(&tmp_ctx, ct2, sizeof(ct2));
 	sm3_finish(&tmp_ctx, Ha + 32);
 	sm9_fn_from_hash(h2, Ha);
 	if (sm9_fn_equ(h2, sig->h) != 1) {

--- a/src/tls12.c
+++ b/src/tls12.c
@@ -247,7 +247,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 	tls_record_set_protocol(finished_record, conn->protocol);
 
 	// 准备Finished Context（和ClientVerify）
-	sm3_init(&sm3_ctx);
+	GMSSL_sm3_init(&sm3_ctx);
 	if (conn->client_certs_len)
 		sm2_sign_init(&sign_ctx, &conn->sign_key, SM2_DEFAULT_ID, SM2_DEFAULT_ID_LENGTH);
 
@@ -282,7 +282,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 		error_print();
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (conn->client_certs_len)
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 
@@ -333,7 +333,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 	memcpy(server_random, random, 32);
 	memcpy(conn->session_id, session_id, session_id_len);
 	conn->cipher_suite = cipher_suite;
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (conn->client_certs_len)
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 
@@ -353,7 +353,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 		tls_send_alert(conn, TLS_alert_unexpected_message);
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (conn->client_certs_len)
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 
@@ -387,7 +387,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 		tls_send_alert(conn, TLS_alert_unexpected_message);
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (conn->client_certs_len)
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 
@@ -439,7 +439,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 			tls_send_alert(conn, TLS_alert_unsupported_certificate);
 			goto end;
 		}
-		sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+		GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 
 		// recv ServerHelloDone
@@ -461,7 +461,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 		tls_send_alert(conn, TLS_alert_unexpected_message);
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (conn->client_certs_len)
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 
@@ -478,7 +478,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 			error_print();
 			goto end;
 		}
-		sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+		GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 	}
 
@@ -525,7 +525,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 		error_print();
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (conn->client_certs_len)
 		sm2_sign_update(&sign_ctx, record + 5, recordlen - 5);
 
@@ -544,7 +544,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 			error_print();
 			goto end;
 		}
-		sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+		GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	}
 
 	// send [ChangeCipherSpec]
@@ -573,7 +573,7 @@ int tls12_do_connect(TLS_CONNECT *conn)
 		goto end;
 	}
 	tls12_record_trace(stderr, finished_record, finished_record_len, 0, 0);
-	sm3_update(&sm3_ctx, finished_record + 5, finished_record_len - 5);
+	GMSSL_sm3_update(&sm3_ctx, finished_record + 5, finished_record_len - 5);
 
 	// encrypt Client Finished
 	tls_trace("encrypt Finished\n");
@@ -707,7 +707,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 
 	// ClientKeyExchange
 	SM2_POINT client_ecdhe_point;
-	uint8_t pre_master_secret[SM2_MAX_PLAINTEXT_SIZE]; // sm2_decrypt 保证输出不会溢出
+	uint8_t pre_master_secret[SM2_MAX_PLAINTEXT_SIZE]; // GMSSL_sm2_decrypt 保证输出不会溢出
 	size_t pre_master_secret_len;
 
 	// Finished
@@ -728,7 +728,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 		client_verify = 1;
 
 	// 初始化Finished和客户端验证环境
-	sm3_init(&sm3_ctx);
+	GMSSL_sm3_init(&sm3_ctx);
 	if (client_verify)
 		tls_client_verify_init(&client_verify_ctx);
 
@@ -777,7 +777,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 
 
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (client_verify)
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 
@@ -798,7 +798,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 		error_print();
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (client_verify)
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 
@@ -815,7 +815,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 		error_print();
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (client_verify)
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 
@@ -840,7 +840,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 		error_print();
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (client_verify)
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 
@@ -867,7 +867,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 			error_print();
 			goto end;
 		}
-		sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+		GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 	}
 
@@ -879,7 +879,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 		error_print();
 		goto end;
 	}
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (client_verify)
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 
@@ -904,7 +904,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 			tls_send_alert(conn, TLS_alert_bad_certificate);
 			goto end;
 		}
-		sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+		GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 	}
 
@@ -923,7 +923,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 		goto end;
 	}
 
-	sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+	GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	if (client_verify)
 		tls_client_verify_update(&client_verify_ctx, record + 5, recordlen - 5);
 
@@ -953,7 +953,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 			tls_send_alert(conn, TLS_alert_decrypt_error);
 			goto end;
 		}
-		sm3_update(&sm3_ctx, record + 5, recordlen - 5);
+		GMSSL_sm3_update(&sm3_ctx, record + 5, recordlen - 5);
 	}
 
 	// generate secrets
@@ -1028,7 +1028,7 @@ int tls12_do_accept(TLS_CONNECT *conn)
 
 	// verify ClientFinished
 	memcpy(&tmp_sm3_ctx, &sm3_ctx, sizeof(SM3_CTX));
-	sm3_update(&sm3_ctx, finished_record + 5, finished_record_len - 5);
+	GMSSL_sm3_update(&sm3_ctx, finished_record + 5, finished_record_len - 5);
 	sm3_finish(&tmp_sm3_ctx, sm3_hash);
 	if (tls_prf(conn->master_secret, 48, "client finished", sm3_hash, 32, NULL, 0,
 		sizeof(local_verify_data), local_verify_data) != 1) {

--- a/tests/cmstest.c
+++ b/tests/cmstest.c
@@ -403,8 +403,8 @@ static int test_cms_signer_info_sign(void)
 		return -1;
 	}
 
-	sm3_init(&sm3_ctx);
-	sm3_update(&sm3_ctx, (uint8_t *)"hello", 5);
+	GMSSL_sm3_init(&sm3_ctx);
+	GMSSL_sm3_update(&sm3_ctx, (uint8_t *)"hello", 5);
 
 	cp = p = buf; len = 0;
 	if (cms_signer_info_sign_to_der(
@@ -462,8 +462,8 @@ static int test_cms_signer_infos(void)
 	uint8_t serial_buf[20];
 
 	sm2_key_generate(&sm2_key);
-	sm3_init(&sm3_ctx);
-	sm3_update(&sm3_ctx, (uint8_t *)"hello", 5);
+	GMSSL_sm3_init(&sm3_ctx);
+	GMSSL_sm3_update(&sm3_ctx, (uint8_t *)"hello", 5);
 	x509_name_set(issuer_buf, &issuer_len, sizeof(issuer_buf), "CN", "Beijing", "Haidian", "PKU", "CS", "CA");
 
 

--- a/tests/sm2test.c
+++ b/tests/sm2test.c
@@ -679,7 +679,7 @@ static int test_sm2_encrypt(void)
 	for (i = 0; i < sizeof(lens)/sizeof(lens[0]); i++) {
 		format_print(stderr, 0, 0, "test %d\n", i + 1);
 		format_bytes(stderr, 0, 4, "plaintext", msg, lens[i]);
-		if (sm2_encrypt(&sm2_key, msg, lens[i], cbuf, &clen) != 1) {
+		if (GMSSL_sm2_encrypt(&sm2_key, msg, lens[i], cbuf, &clen) != 1) {
 			error_print();
 			return -1;
 		}
@@ -687,7 +687,7 @@ static int test_sm2_encrypt(void)
 		sm2_ciphertext_print(stderr, 0, 4, "Ciphertext", cbuf, clen);
 		format_print(stderr, 0, 0, "\n");
 
-		if (sm2_decrypt(&sm2_key, cbuf, clen, mbuf, &mlen) != 1) {
+		if (GMSSL_sm2_decrypt(&sm2_key, cbuf, clen, mbuf, &mlen) != 1) {
 			error_print();
 			return -1;
 		}

--- a/tools/sdfutil.c
+++ b/tools/sdfutil.c
@@ -168,12 +168,12 @@ bad:
 		}
 		key_opened = 1;
 
-		sm3_init(&sm3_ctx);
+		GMSSL_sm3_init(&sm3_ctx);
 		sm2_compute_z(dgst, &(key.public_key.public_key), id, strlen(id));
-		sm3_update(&sm3_ctx, dgst, sizeof(dgst));
+		GMSSL_sm3_update(&sm3_ctx, dgst, sizeof(dgst));
 
 		while ((len = fread(buf, 1, sizeof(buf), infp)) > 0) {
-			sm3_update(&sm3_ctx, buf, len);
+			GMSSL_sm3_update(&sm3_ctx, buf, len);
 		}
 		sm3_finish(&sm3_ctx, dgst);
 

--- a/tools/skfutil.c
+++ b/tools/skfutil.c
@@ -225,12 +225,12 @@ bad:
 		}
 		key_opened = 1;
 
-		sm3_init(&sm3_ctx);
+		GMSSL_sm3_init(&sm3_ctx);
 		sm2_compute_z(dgst, &(key.public_key.public_key), id, strlen(id));
-		sm3_update(&sm3_ctx, dgst, sizeof(dgst));
+		GMSSL_sm3_update(&sm3_ctx, dgst, sizeof(dgst));
 
 		while ((len = fread(buf, 1, sizeof(buf), infp)) > 0) {
-			sm3_update(&sm3_ctx, buf, len);
+			GMSSL_sm3_update(&sm3_ctx, buf, len);
 		}
 		sm3_finish(&sm3_ctx, dgst);
 

--- a/tools/sm2decrypt.c
+++ b/tools/sm2decrypt.c
@@ -101,7 +101,7 @@ bad:
 		fprintf(stderr, "%s: read input failed : %s\n", prog, strerror(errno));
 		goto end;
 	}
-	if (sm2_decrypt(&key, inbuf, inlen, outbuf, &outlen) != 1) {
+	if (GMSSL_sm2_decrypt(&key, inbuf, inlen, outbuf, &outlen) != 1) {
 		fprintf(stderr, "%s: decryption failure\n", prog);
 		goto end;
 	}

--- a/tools/sm2encrypt.c
+++ b/tools/sm2encrypt.c
@@ -124,7 +124,7 @@ bad:
 		goto end;
 	}
 
-	if (sm2_encrypt(&key, inbuf, inlen, outbuf, &outlen) != 1) {
+	if (GMSSL_sm2_encrypt(&key, inbuf, inlen, outbuf, &outlen) != 1) {
 		fprintf(stderr, "%s: inner error\n", prog);
 		goto end;
 	}

--- a/tools/sm3.c
+++ b/tools/sm3.c
@@ -90,7 +90,7 @@ bad:
 		argv++;
 	}
 
-	sm3_init(&sm3_ctx);
+	GMSSL_sm3_init(&sm3_ctx);
 
 	if (pubkeyfile) {
 		SM2_KEY sm2_key;
@@ -105,7 +105,7 @@ bad:
 		}
 
 		sm2_compute_z(z, (SM2_POINT *)&sm2_key, id, strlen(id));
-		sm3_update(&sm3_ctx, z, sizeof(z));
+		GMSSL_sm3_update(&sm3_ctx, z, sizeof(z));
 	} else {
 		if (id) {
 			fprintf(stderr, "%s: option '-id' must be with '-pubkey'\n", prog);
@@ -114,7 +114,7 @@ bad:
 	}
 
 	while ((len = fread(buf, 1, sizeof(buf), infp)) > 0) {
-		sm3_update(&sm3_ctx, buf, len);
+		GMSSL_sm3_update(&sm3_ctx, buf, len);
 	}
 	sm3_finish(&sm3_ctx, dgst);
 


### PR DESCRIPTION
fix duplicate symbol when link both gmssl and openssl:

duplicate symbol '_OPENSSL_hexchar2int' in:
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(o_str.o)
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(hex.o)
duplicate symbol '_OPENSSL_hexstr2buf' in:
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(o_str.o)
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(hex.o)
duplicate symbol '_sm2_encrypt' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm2_lib.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm2_crypt.o)
duplicate symbol '_sm2_decrypt' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm2_lib.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm2_crypt.o)
duplicate symbol '_sm2_do_verify' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm2_lib.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm2_sign.o)
duplicate symbol '_sm2_verify' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm2_lib.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm2_sign.o)
duplicate symbol '_sm2_do_sign' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm2_lib.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm2_sign.o)
duplicate symbol '_sm2_sign' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm2_lib.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm2_sign.o)
duplicate symbol '_sm3_init' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm3.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm3.o)
duplicate symbol '_sm3_update' in:
    /.../.nih_c/xcode/AppleClang_13.1.6.13160021/lib/libgmssl.a(sm3.o)
    /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a(sm3.o)
