### PR TITLE
fix cmake build error on mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,9 @@ else()
 	target_link_libraries(gmssl dl)
 endif()
 
-
+if(MINGW)
+	target_link_libraries(gmssl PRIVATE wsock32)
+endif()
 
 SET_TARGET_PROPERTIES(gmssl PROPERTIES VERSION 3.0 SOVERSION 3)
 
@@ -230,6 +232,9 @@ if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
 	add_executable(gmssl-bin ${tools})
 	target_link_libraries (gmssl-bin LINK_PUBLIC gmssl)
 	set_target_properties (gmssl-bin PROPERTIES RUNTIME_OUTPUT_NAME gmssl)
+	if(MINGW)
+		target_link_libraries(gmssl-bin PRIVATE Ws2_32)
+	endif()
 
 	enable_testing()
 	foreach(name ${tests})


### PR DESCRIPTION
补充了缺少的wsock32.lib和Ws2_32.lib以在MinGW上通过编译。
在msys2的UCRT64环境下，使用GCC12.2编译通过。