### PR TITLE
optimize sm9 miller loop

### DIFF
--- a/src/sm9_alg.c
+++ b/src/sm9_alg.c
@@ -2015,7 +2015,7 @@ void sm9_final_exponent(sm9_fp12_t r, const sm9_fp12_t f)
 }
 
 void sm9_pairing(sm9_fp12_t r, const SM9_TWIST_POINT *Q, const SM9_POINT *P) {
-	const char *abits = "00100000000000000000000000000000000000010000101011101100100111110";
+	const char *abits = "00100000000000000000000000000000000000010000101100020200101000020";
 
 	SM9_TWIST_POINT _T, *T = &_T;
 	SM9_TWIST_POINT _Q1, *Q1 = &_Q1;
@@ -2031,9 +2031,8 @@ void sm9_pairing(sm9_fp12_t r, const SM9_TWIST_POINT *Q, const SM9_POINT *P) {
 
 	sm9_fp12_set_one(f_num);
 	sm9_fp12_set_one(f_den);
-
+	
 	for (i = 0; i < strlen(abits); i++) {
-
 		sm9_fp12_sqr(f_num, f_num);
 		sm9_fp12_sqr(f_den, f_den);
 		sm9_eval_g_tangent(g_num, g_den, T, P);
@@ -2047,6 +2046,12 @@ void sm9_pairing(sm9_fp12_t r, const SM9_TWIST_POINT *Q, const SM9_POINT *P) {
 			sm9_fp12_mul(f_num, f_num, g_num);
 			sm9_fp12_mul(f_den, f_den, g_den);
 			sm9_twist_point_add_full(T, T, Q);
+		} else if (abits[i] == '2') {
+			sm9_twist_point_neg(Q1, Q);
+			sm9_eval_g_line(g_num, g_den, T, Q1, P);
+			sm9_fp12_mul(f_num, f_num, g_num);
+			sm9_fp12_mul(f_den, f_den, g_den);
+			sm9_twist_point_add_full(T, T, Q1);
 		}
 	}
 


### PR DESCRIPTION
根据论文[1]优化了SM9双线性对中的miller loop。根据论文，miller loop性能有5.2%的提升。

[1] Ping Zhen, Xiaobo Hu, Yanyan Yu, Liang Liu, and Haifeng Zhang. 2017. Research on the Optimization Computation of SM9 Bilinear Pairings. In Proceedings of the 2017 2nd International Conference on Communication and Information Systems (ICCIS 2017). https://doi.org/10.1145/3158233.3159381