### PR TITLE
add link libraries ws2_32, fix win32 compile error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ add_library(gmssl ${src})
 
 
 if (WIN32)
+	target_link_libraries(gmssl -lws2_32)
 elseif (APPLE)
 	target_link_libraries(gmssl dl)
 	target_link_libraries(gmssl "-framework Security")


### PR DESCRIPTION
hi guanzhi, i'm tring to compile under win10 & clion & MinGW. while compiling under windows, socket function of send() and recv() is undefined.  I guess we should add link library ws2_32.[similar question on stackoverflow](https://stackoverflow.com/questions/2033608/mingw-linker-error-winsock)