### PR TITLE
Update zuc_modes.c

### DIFF
--- a/src/zuc_modes.c
+++ b/src/zuc_modes.c
@@ -44,7 +44,7 @@ void zuc_eea_encrypt(const ZUC_UINT32 *in, ZUC_UINT32 *out, size_t nbits,
 	}
 
 	if (nbits % 32 != 0) {
-		out[nwords - 1] |= (0xffffffff << (32 - (nbits%32)));
+		out[nwords - 1] &= (0xffffffff << (32 - (nbits%32)));
 	}
 }
 


### PR DESCRIPTION
In function zuc_eea_encrypt, modify the operator |= to &=.

Encryption example:
key={0x17, 0x3d, 0x14, 0xba, 0x50, 0x03, 0x73, 0x1d, 0x7a, 0x60, 0x04, 0x94, 0x70, 0xf0, 0x0a, 0x29}
count=0x66035492
bearer=0x0f
direction=0
length=c1
ibs={0x6cf65340, 0x735552ab, 0x0c9752fa, 0x6f9025fe, 0x0bd675d9, 0x005875b2, 0x00000000}
obs={0xa6c85fc6, 0x6afb8533, 0xaafc2518, 0xdfe78494, 0x0ee1e4b0, 0x30238cc8, 0x00000000}

In current code, the obs of the encryption is:
{0xa6c85fc6, 0x6afb8533, 0xaafc2518, 0xdfe78494, 0x0ee1e4b0, 0x30238cc8, 0x904b5a43}
An error occurred in the encryption result of the last word due to an incorrect operation on the last word.