### PR TITLE
优化sm9_fp12_sqr()函数

### DIFF
--- a/src/sm9_alg.c
+++ b/src/sm9_alg.c
@@ -180,7 +180,6 @@ void sm9_bn_set_word(sm9_bn_t r, uint32_t a)
 	r[0] = a;
 }
 
-//r = a + b
 void sm9_bn_add(sm9_bn_t r, const sm9_bn_t a, const sm9_bn_t b)
 {
 	int i;
@@ -193,7 +192,6 @@ void sm9_bn_add(sm9_bn_t r, const sm9_bn_t a, const sm9_bn_t b)
 	}
 }
 
-//ret = a - b;
 void sm9_bn_sub(sm9_bn_t ret, const sm9_bn_t a, const sm9_bn_t b)
 {
 	int i;
@@ -229,7 +227,6 @@ int sm9_bn_equ(const sm9_bn_t a, const sm9_bn_t b)
 	return 1;
 }
 
-//r=a+b,超出则模p
 void sm9_fp_add(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 {
 	sm9_bn_add(r, a, b);
@@ -238,8 +235,6 @@ void sm9_fp_add(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 	}
 }
 
-//若a>b,r=a-b
-//若a<b,r=a-b+p
 void sm9_fp_sub(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 {
 	if (sm9_bn_cmp(a, b) >= 0) {
@@ -445,8 +440,6 @@ void sm9_fp_pow(sm9_fp_t r, const sm9_fp_t a, const sm9_bn_t e)
 	sm9_bn_copy(r, t);
 }
 
-//e = p - 2;
-//r = a^e;
 void sm9_fp_inv(sm9_fp_t r, const sm9_fp_t a)
 {
 	sm9_fp_t e;
@@ -542,14 +535,12 @@ void sm9_fp2_to_hex(const sm9_fp2_t a, char hex[129])
 	sm9_fp_to_hex(a[0], hex + 65);
 }
 
-//将sm9_fp_t类型a转化为sm9_fp2_t类型r，扩展位置0
 void sm9_fp2_set_fp(sm9_fp2_t r, const sm9_fp_t a)
 {
 	sm9_fp_copy(r[0], a);
 	sm9_fp_set_zero(r[1]);
 }
 
-//将sm9_fp_t类型a0,a1合为sm9_fp2_t类型r
 void sm9_fp2_set(sm9_fp2_t r, const sm9_fp_t a0, const sm9_fp_t a1)
 {
 	sm9_fp_copy(r[0], a0);
@@ -605,7 +596,6 @@ void sm9_fp2_mul(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp2_t b)
 	sm9_fp_copy(r[1], r1);
 }
 
-//a*b*u
 void sm9_fp2_mul_u(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp2_t b)
 {
 	sm9_fp_t r0, r1, t;
@@ -627,7 +617,6 @@ void sm9_fp2_mul_u(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp2_t b)
 	sm9_fp_copy(r[1], r1);
 }
 
-//fp2类型a * fp类型k
 void sm9_fp2_mul_fp(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp_t k)
 {
 	sm9_fp_mul(r[0], a[0], k);
@@ -786,35 +775,30 @@ void sm9_fp4_to_hex(const sm9_fp4_t a, char hex[259])
 	sm9_fp2_to_hex(a[0], hex + 130);
 }
 
-//fp类型a，扩展为，fp4类型r
 void sm9_fp4_set_fp(sm9_fp4_t r, const sm9_fp_t a)
 {
 	sm9_fp2_set_fp(r[0], a);
 	sm9_fp2_set_zero(r[1]);
 }
 
-//fp2类型a，扩展为，fp4类型r
 void sm9_fp4_set_fp2(sm9_fp4_t r, const sm9_fp2_t a)
 {
 	sm9_fp2_copy(r[0], a);
 	sm9_fp2_set_zero(r[1]);
 }
 
-//fp2类型a0，fp2类型a1，合并为fp4类型r
 void sm9_fp4_set(sm9_fp4_t r, const sm9_fp2_t a0, const sm9_fp2_t a1)
 {
 	sm9_fp2_copy(r[0], a0);
 	sm9_fp2_copy(r[1], a1);
 }
 
-//r置为u
 void sm9_fp4_set_u(sm9_fp4_t r)
 {
 	sm9_fp2_set_u(r[0]);
 	sm9_fp2_set_zero(r[1]);
 }
 
-//r置为v
 void sm9_fp4_set_v(sm9_fp4_t r)
 {
 	sm9_fp2_set_zero(r[0]);
@@ -1218,16 +1202,6 @@ void sm9_fp12_sqr(sm9_fp12_t r, const sm9_fp12_t a)
 	
 	sm9_fp4_sub(t, s3, h1);
 	sm9_fp4_sub(h2, t, h0);
-
-	// sm9_fp4_set_v(t);
-	// sm9_fp4_mul(h1, h1, t);
-	// sm9_fp4_add(h1, h1, s0);
-	// sm9_fp4_sub(h1, h1, s2);
-	// sm9_fp4_sub(h1, h1, s3);
-
-	// sm9_fp4_set_v(t);
-	// sm9_fp4_mul(t, s2, t);
-	// sm9_fp4_add(h0, h0, t);
 
 	sm9_fp4_a_mul_v(h1, h1);
 	sm9_fp4_add(h1, h1, s0);

--- a/src/sm9_alg.c
+++ b/src/sm9_alg.c
@@ -180,6 +180,7 @@ void sm9_bn_set_word(sm9_bn_t r, uint32_t a)
 	r[0] = a;
 }
 
+//r = a + b
 void sm9_bn_add(sm9_bn_t r, const sm9_bn_t a, const sm9_bn_t b)
 {
 	int i;
@@ -192,6 +193,7 @@ void sm9_bn_add(sm9_bn_t r, const sm9_bn_t a, const sm9_bn_t b)
 	}
 }
 
+//ret = a - b;
 void sm9_bn_sub(sm9_bn_t ret, const sm9_bn_t a, const sm9_bn_t b)
 {
 	int i;
@@ -227,6 +229,7 @@ int sm9_bn_equ(const sm9_bn_t a, const sm9_bn_t b)
 	return 1;
 }
 
+//r=a+b,超出则模p
 void sm9_fp_add(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 {
 	sm9_bn_add(r, a, b);
@@ -235,6 +238,8 @@ void sm9_fp_add(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 	}
 }
 
+//若a>b,r=a-b
+//若a<b,r=a-b+p
 void sm9_fp_sub(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 {
 	if (sm9_bn_cmp(a, b) >= 0) {
@@ -440,6 +445,8 @@ void sm9_fp_pow(sm9_fp_t r, const sm9_fp_t a, const sm9_bn_t e)
 	sm9_bn_copy(r, t);
 }
 
+//e = p - 2;
+//r = a^e;
 void sm9_fp_inv(sm9_fp_t r, const sm9_fp_t a)
 {
 	sm9_fp_t e;
@@ -535,12 +542,14 @@ void sm9_fp2_to_hex(const sm9_fp2_t a, char hex[129])
 	sm9_fp_to_hex(a[0], hex + 65);
 }
 
+//将sm9_fp_t类型a转化为sm9_fp2_t类型r，扩展位置0
 void sm9_fp2_set_fp(sm9_fp2_t r, const sm9_fp_t a)
 {
 	sm9_fp_copy(r[0], a);
 	sm9_fp_set_zero(r[1]);
 }
 
+//将sm9_fp_t类型a0,a1合为sm9_fp2_t类型r
 void sm9_fp2_set(sm9_fp2_t r, const sm9_fp_t a0, const sm9_fp_t a1)
 {
 	sm9_fp_copy(r[0], a0);
@@ -596,6 +605,7 @@ void sm9_fp2_mul(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp2_t b)
 	sm9_fp_copy(r[1], r1);
 }
 
+//a*b*u
 void sm9_fp2_mul_u(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp2_t b)
 {
 	sm9_fp_t r0, r1, t;
@@ -617,6 +627,7 @@ void sm9_fp2_mul_u(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp2_t b)
 	sm9_fp_copy(r[1], r1);
 }
 
+//fp2类型a * fp类型k
 void sm9_fp2_mul_fp(sm9_fp2_t r, const sm9_fp2_t a, const sm9_fp_t k)
 {
 	sm9_fp_mul(r[0], a[0], k);
@@ -775,30 +786,35 @@ void sm9_fp4_to_hex(const sm9_fp4_t a, char hex[259])
 	sm9_fp2_to_hex(a[0], hex + 130);
 }
 
+//fp类型a，扩展为，fp4类型r
 void sm9_fp4_set_fp(sm9_fp4_t r, const sm9_fp_t a)
 {
 	sm9_fp2_set_fp(r[0], a);
 	sm9_fp2_set_zero(r[1]);
 }
 
+//fp2类型a，扩展为，fp4类型r
 void sm9_fp4_set_fp2(sm9_fp4_t r, const sm9_fp2_t a)
 {
 	sm9_fp2_copy(r[0], a);
 	sm9_fp2_set_zero(r[1]);
 }
 
+//fp2类型a0，fp2类型a1，合并为fp4类型r
 void sm9_fp4_set(sm9_fp4_t r, const sm9_fp2_t a0, const sm9_fp2_t a1)
 {
 	sm9_fp2_copy(r[0], a0);
 	sm9_fp2_copy(r[1], a1);
 }
 
+//r置为u
 void sm9_fp4_set_u(sm9_fp4_t r)
 {
 	sm9_fp2_set_u(r[0]);
 	sm9_fp2_set_zero(r[1]);
 }
 
+//r置为v
 void sm9_fp4_set_v(sm9_fp4_t r)
 {
 	sm9_fp2_set_zero(r[0]);
@@ -1120,28 +1136,110 @@ void sm9_fp12_mul(sm9_fp12_t r, const sm9_fp12_t a, const sm9_fp12_t b)
 	sm9_fp4_copy(r[2], r2);
 }
 
+// void sm9_fp12_sqr(sm9_fp12_t r, const sm9_fp12_t a)
+// {
+// 	sm9_fp4_t r0, r1, r2, t;
+
+// 	sm9_fp4_sqr(r0, a[0]);
+// 	sm9_fp4_mul_v(t, a[1], a[2]);
+// 	sm9_fp4_dbl(t, t);
+// 	sm9_fp4_add(r0, r0, t);
+
+// 	sm9_fp4_mul(r1, a[0], a[1]);
+// 	sm9_fp4_dbl(r1, r1);
+// 	sm9_fp4_sqr_v(t, a[2]);
+// 	sm9_fp4_add(r1, r1, t);
+
+// 	sm9_fp4_mul(r2, a[0], a[2]);
+// 	sm9_fp4_dbl(r2, r2);
+// 	sm9_fp4_sqr(t, a[1]);
+// 	sm9_fp4_add(r2, r2, t);
+
+// 	sm9_fp4_copy(r[0], r0);
+// 	sm9_fp4_copy(r[1], r1);
+// 	sm9_fp4_copy(r[2], r2);
+// }
+
+void sm9_fp4_div2(sm9_fp4_t r, const sm9_fp4_t a)
+{
+	sm9_fp2_div2(r[0], a[0]);
+	sm9_fp2_div2(r[1], a[1]);
+}
+
+void sm9_fp2_a_mul_u(sm9_fp2_t r, sm9_fp2_t a) {
+	sm9_fp_t r0, a0, a1;
+
+	sm9_fp_copy(a0, a[0]);
+	sm9_fp_copy(a1, a[1]);
+	
+	//r0 = -2 * a1
+	sm9_fp_dbl(r0, a1);
+	sm9_fp_neg(r0, r0);
+	sm9_fp_copy(r[0], r0);
+
+	//r1 = a0
+	sm9_fp_copy(r[1], a0);
+}
+
+void sm9_fp4_a_mul_v(sm9_fp4_t r, sm9_fp4_t a) {
+	sm9_fp2_t r0, a0, a1;
+
+	sm9_fp2_copy(a0, a[0]);
+	sm9_fp2_copy(a1, a[1]);
+
+	//r0 = a1 * u
+	sm9_fp2_a_mul_u(r0, a1);
+	sm9_fp2_copy(r[0], r0);
+
+	//r1 = a0
+	sm9_fp2_copy(r[1], a0);
+}
+
 void sm9_fp12_sqr(sm9_fp12_t r, const sm9_fp12_t a)
 {
-	sm9_fp4_t r0, r1, r2, t;
+	sm9_fp4_t h0, h1, h2, t;
+	sm9_fp4_t s0, s1, s2, s3;
 
-	sm9_fp4_sqr(r0, a[0]);
-	sm9_fp4_mul_v(t, a[1], a[2]);
-	sm9_fp4_dbl(t, t);
-	sm9_fp4_add(r0, r0, t);
+	sm9_fp4_sqr(h0, a[0]);
+	sm9_fp4_sqr(h1, a[2]);
+	sm9_fp4_add(s0, a[2], a[0]);
 
-	sm9_fp4_mul(r1, a[0], a[1]);
-	sm9_fp4_dbl(r1, r1);
-	sm9_fp4_sqr_v(t, a[2]);
-	sm9_fp4_add(r1, r1, t);
+	sm9_fp4_sub(t, s0, a[1]);
+	sm9_fp4_sqr(s1, t);
 
-	sm9_fp4_mul(r2, a[0], a[2]);
-	sm9_fp4_dbl(r2, r2);
-	sm9_fp4_sqr(t, a[1]);
-	sm9_fp4_add(r2, r2, t);
+	sm9_fp4_add(t, s0, a[1]);
+	sm9_fp4_sqr(s0, t);
 
-	sm9_fp4_copy(r[0], r0);
-	sm9_fp4_copy(r[1], r1);
-	sm9_fp4_copy(r[2], r2);
+	sm9_fp4_mul(s2, a[1], a[2]);
+	sm9_fp4_dbl(s2, s2);
+
+	sm9_fp4_add(s3, s0, s1);
+	sm9_fp4_div2(s3, s3);
+	
+	sm9_fp4_sub(t, s3, h1);
+	sm9_fp4_sub(h2, t, h0);
+
+	// sm9_fp4_set_v(t);
+	// sm9_fp4_mul(h1, h1, t);
+	// sm9_fp4_add(h1, h1, s0);
+	// sm9_fp4_sub(h1, h1, s2);
+	// sm9_fp4_sub(h1, h1, s3);
+
+	// sm9_fp4_set_v(t);
+	// sm9_fp4_mul(t, s2, t);
+	// sm9_fp4_add(h0, h0, t);
+
+	sm9_fp4_a_mul_v(h1, h1);
+	sm9_fp4_add(h1, h1, s0);
+	sm9_fp4_sub(h1, h1, s2);
+	sm9_fp4_sub(h1, h1, s3);
+
+	sm9_fp4_a_mul_v(s2, s2);
+	sm9_fp4_add(h0, h0, s2);
+
+	sm9_fp4_copy(r[0], h0);
+	sm9_fp4_copy(r[1], h1);
+	sm9_fp4_copy(r[2], h2);
 }
 
 void sm9_fp12_inv(sm9_fp12_t r, const sm9_fp12_t a)


### PR DESCRIPTION
优化了sm9_fp12_sqr()函数，相比原始方法，减少了一些运算。

优化方法来自文献[1]，将其中SQR3方法用于扩域Fp12 元素的平方运算。

[1]CHUNG J, HASAN M A. Asymmetric squaring formulae[C]. In: Proceedings of 18th IEEE Symposium on Computer Arithmetic (ARITH 2007). IEEE, 2007: 113–122. [DOI: 10.1109/ARITH.2007.11]