### PR TITLE
optimize sm9_fp_mul

### DIFF
--- a/src/sm9_alg.c
+++ b/src/sm9_alg.c
@@ -357,7 +357,7 @@ void sm9_fp_mul(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 	}
 
 	/* q = zh * mu // (2^32)^9 */
-	for (i = 0; i < 18; i++) {
+	for (i = 0; i < 9; i++) {
 		s[i] = 0;
 	}
 	for (i = 0; i < 9; i++) {
@@ -374,17 +374,23 @@ void sm9_fp_mul(sm9_fp_t r, const sm9_fp_t a, const sm9_fp_t b)
 	}
 
 	/* q = q * p mod (2^32)^9 */
-	for (i = 0; i < 18; i++) {
+	for (i = 0; i < 8; i++) {
 		s[i] = 0;
 	}
-	for (i = 0; i < 9; i++) {
+	w = 0;
+    for (j = 0; j < 8; j++) {
+		w += s[j] + q[0] * SM9_P[j];
+ 		s[j] = w & 0xffffffff;
+		w >>= 32;
+	}
+	s[8] = w;
+	for (i = 1; i < 9; i++) {
 		w = 0;
-		for (j = 0; j < 8; j++) {
+		for (j = 0; i + j < 9; j++) {
 			w += s[i + j] + q[i] * SM9_P[j];
 			s[i + j] = w & 0xffffffff;
 			w >>= 32;
 		}
-		s[i + 8] = w;
 	}
 	for (i = 0; i < 9; i++) {
 		q[i] = s[i];


### PR DESCRIPTION
优化了sm9中sm9_fp_mul函数，减少了不必要的运算。

经测试，该优化对sm9签名大约有10%的性能提升，下图分别为在github codespaces中使用优化前和优化后的sm9_fp_mul函数进行100次sm9签名的时间对比。

优化前：
![image](https://user-images.githubusercontent.com/126303062/221330829-908639ef-4a00-4c66-becc-59b893503392.png)

优化后：
![image](https://user-images.githubusercontent.com/126303062/221330843-f6e6dda9-a8b7-44f5-8f16-17a855975c15.png)
