### PR TITLE
修复gmssl在vc2010下编译相关问题

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3463,6 +3463,7 @@ int speed_main(int argc, char **argv)
             ERR_print_errors(bio_err);
             rsa_count = 1;
         } else {
+            size_t len = 0;
             for (i = 0; i < loopargs_len; i++) {
             	/* these 2 lines should be modified ? */
                 /*if (!nopre)
@@ -3499,7 +3500,7 @@ int speed_main(int argc, char **argv)
             /* Perform SM9 verification test */
             for (i = 0; i < loopargs_len; i++) {
             	loopargs[i].sm9sk[testnum] = SM9_extract_private_key(loopargs[i].sm9mst[testnum], sm9enc_id, sm9enc_idlen);
-                size_t len = loopargs[i].cipherlen;
+                len = loopargs[i].cipherlen;
                 st = SM9_decrypt(NID_sm3, loopargs[i].buf2, loopargs[i].cipherlen,
                                  loopargs[i].buf, &len, loopargs[i].sm9sk[testnum]);
                 if (st == 0)

--- a/crypto/sm9/sm9_asn1.c
+++ b/crypto/sm9/sm9_asn1.c
@@ -293,12 +293,13 @@ int SM9_signature_size(const SM9_MASTER_KEY *params)
 int SM9_ciphertext_size(const SM9_MASTER_KEY *params, size_t inlen)
 {
 	int ret;
+	int len = 0;
 	ASN1_OCTET_STRING s;
 	s.type = V_ASN1_OCTET_STRING;
 	s.data = NULL;
-	int len = 0;
-
-	if (inlen > SM9_MAX_PLAINTEXT_LENGTH) {
+	
+	if (inlen > SM9_MAX_PLAINTEXT_LENGTH) 
+	{
 		SM9err(SM9_F_SM9_CIPHERTEXT_SIZE, SM9_R_PLAINTEXT_TOO_LONG);
 		return 0;
 	}
@@ -321,6 +322,6 @@ int SM9_ciphertext_size(const SM9_MASTER_KEY *params, size_t inlen)
 	s.length = inlen;
 	len += i2d_ASN1_OCTET_STRING(&s, NULL);
 
-	ret = ASN1_object_size(1, len, V_ASN1_SEQUENCE);
+	ret = ASN1_object_size(1, len, V_ASN1_SEQUENCE);	
 	return ret;
 }

--- a/crypto/sm9/sm9_rate.c
+++ b/crypto/sm9/sm9_rate.c
@@ -1304,14 +1304,14 @@ int fp12_sqr(fp12_t r, const fp12_t a, const BIGNUM *p, BN_CTX *ctx)
 
 int fp12_inv(fp12_t r, const fp12_t a, const BIGNUM *p, BN_CTX *ctx)
 {
+	fp4_t r0, r1, r2;
 	if (fp4_is_zero(a[2])) {
 		fp4_t k;
 		fp4_t t;
 		if (!fp4_init(t, ctx)) {
 			return 0;
 		}
-
-		fp4_t r0, r1, r2;
+		
 		fp4_init(r0, ctx); // FIXME: r0, r1, r2 never used
 		fp4_init(r1, ctx);
 		fp4_init(r2, ctx);
@@ -2241,6 +2241,7 @@ int point_test(const BIGNUM *p, BN_CTX *ctx)
 	point_t G, P;
 	BIGNUM *k = BN_new();
 	int ok;
+	fp12_t x, y;
 
 	point_init(&G, ctx);
 	point_init(&P, ctx);
@@ -2282,8 +2283,6 @@ int point_test(const BIGNUM *p, BN_CTX *ctx)
 	point_mul_generator(&P, k, p, ctx);
 	ok = point_equ_hex(&P, Ppubs, ctx);
 	printf("point test %d: %s\n", __LINE__, ok ? "ok" : "error");
-
-	fp12_t x, y;
 
 	fp12_init(x, ctx);
 	fp12_init(y, ctx);

--- a/ssl/statem/statem_gmtls.c
+++ b/ssl/statem/statem_gmtls.c
@@ -302,11 +302,11 @@ static int gmtls_process_sm9_params(SSL *s, PACKET *pkt, int *al, int ibe)
 
 int gmtls_construct_server_certificate(SSL *s)
 {
-	unsigned long alg_a;
-	alg_a = s->s3->tmp.new_cipher->algorithm_auth;
 	int l;
 	unsigned char *p;
     int al = -1;
+	unsigned long alg_a;
+	alg_a = s->s3->tmp.new_cipher->algorithm_auth;
 
 	l = 3 + SSL_HM_HEADER_LENGTH(s);
 


### PR DESCRIPTION
估计是vs2010 c编译器对变量声明的位置有要求，导致部分代码在编译时报“未声明的标识符”。
通过调整变量的声明位置到函数的开始处，即可通过编译。
除了修改代码，不知道还有没有其他处理办法，暂且先pull一下！