### PR TITLE
增加sm2 public key parse demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ set(demos
 	demo_sm2_private_key
 	demo_sm2_private_key_parse
 	demo_sm2_public_key
-    demo_sm2_public_key_parse
+      demo_sm2_public_key_parse
 	demo_sm2_sign
 	demo_sm2_sign_ctx
 	demo_sm3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ set(demos
 	demo_sm2_private_key
 	demo_sm2_private_key_parse
 	demo_sm2_public_key
-      demo_sm2_public_key_parse
+    demo_sm2_public_key_parse
 	demo_sm2_sign
 	demo_sm2_sign_ctx
 	demo_sm3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ set(demos
 	demo_sm2_private_key
 	demo_sm2_private_key_parse
 	demo_sm2_public_key
+      demo_sm2_public_key_parse
 	demo_sm2_sign
 	demo_sm2_sign_ctx
 	demo_sm3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,6 @@ set(demos
 	demo_sm2_private_key
 	demo_sm2_private_key_parse
 	demo_sm2_public_key
-    demo_sm2_public_key_parse
 	demo_sm2_sign
 	demo_sm2_sign_ctx
 	demo_sm3

--- a/demos/src/demo_sm2_public_key_parse.c
+++ b/demos/src/demo_sm2_public_key_parse.c
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2014-2022 The GmSSL Project. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the License); you may
+ *  not use this file except in compliance with the License.
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <gmssl/mem.h>
+#include <gmssl/sm2.h>
+
+
+int main(void)
+{
+	SM2_KEY sm2_key;
+
+	printf("Read SM2 public key file (PEM) from stdin ...\n");
+	
+	if (sm2_public_key_info_from_pem(&sm2_key, stdin) != 1) {
+		fprintf(stderr, "error\n");
+		return 1;
+	}
+	
+	sm2_public_key_print(stdout, 0, 0, "SM2PublicKey", &sm2_key);
+
+	gmssl_secure_clear(&sm2_key, sizeof(sm2_key));
+	return 0;
+}


### PR DESCRIPTION
增加sm2 public key parse demo，通过标准输入输入sm2公钥pem文件，然后解析成sm2key结构体后将通过标准输出输出sm2key结构体的公钥