### PR TITLE
Update demo_sm2_private_key_parse.c

### DIFF
--- a/demos/src/demo_sm2_private_key_parse.c
+++ b/demos/src/demo_sm2_private_key_parse.c
@@ -34,8 +34,8 @@ int main(void)
 		fprintf(stderr, "error\n");
 		return 1;
 	}
-	fwrite(buf, 1, len, stdout);
-
+	sm2_key_print(stdout, 0, 0, "SM2PrivateKey", &sm2_key);
+	
 	gmssl_secure_clear(&sm2_key, sizeof(sm2_key));
 	return 0;
 }


### PR DESCRIPTION
原先的输出显示在乌班图控制界面上是一堆乱码，改进后调用源码中的sm2_key_print函数打印sm2key的结构体