### PR TITLE
fix: sm2_point_from_x函数内的表达式应该明确优先级

### DIFF
--- a/src/sm2_alg.c
+++ b/src/sm2_alg.c
@@ -1115,7 +1115,7 @@ int sm2_point_from_x(SM2_POINT *P, const uint8_t x[32], int y)
 		return -1;
 	}
 
-	if ((y == 0x02 && sm2_bn_is_odd(_y)) || (y == 0x03) && !sm2_bn_is_odd(_y)) {
+	if ((y == 0x02 && sm2_bn_is_odd(_y)) || ((y == 0x03) && !sm2_bn_is_odd(_y))) {
 		sm2_fp_neg(_y, _y);
 	}
 


### PR DESCRIPTION
````
if ((y == 0x02 && sm2_bn_is_odd(_y)) || (y == 0x03) && !sm2_bn_is_odd(_y)) {
```

后半段的优先级应该加括号包起来