### PR TITLE
#issue1446 : 修复x86 ubuntu16 链接_rdseed64_step找不到问题

### DIFF
--- a/src/rdrand.c
+++ b/src/rdrand.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <gmssl/error.h>
 #include <immintrin.h>
+#include <x86intrin.h>
 
 int rdrand_bytes(uint8_t *buf, size_t buflen)
 {


### PR DESCRIPTION
修复x86 ubuntu16 链接_rdseed64_step找不到问题
#1446 