### PR TITLE
Fix bug not including sm2_z256.h

### DIFF
--- a/src/sm2_z256.c
+++ b/src/sm2_z256.c
@@ -50,6 +50,7 @@
 #include <gmssl/error.h>
 #include <gmssl/hex.h>
 #include <gmssl/endian.h>
+#include <gmssl/sm2_z256.h>
 
 
 // z256


### PR DESCRIPTION
not include <gmssl/sm2_z256.h> in  src/sm2_z256.c