### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ GmSSL通过子项目提供多种多种编程语言绑定
  * [GmSSL-Java](https://github.com/GmSSL/GmSSL-Java) 以JNI方式实现的Java语言绑定
  * [GmSSL-PHP](https://github.com/GmSSL/GmSSL-PHP) 以PHP扩展方式实现的PHP语言绑定
  * [GmSSL-Go](https://github.com/GmSSL/GmSSL-Go) 以CGO方式实现的Go语言绑定
- * [GmSSL-Python](https://github.com/GmSSL/GmSSL-Python) 以CGO方式实现的Go语言绑定
+ * [GmSSL-Python](https://github.com/GmSSL/GmSSL-Python) 以ctypes方式实现的Python语言绑定
  * [GmSSL-JS](https://github.com/guanzhi/GmSSL-JS) 纯JavaScript实现的国密算法库
 
 ## 典型应用


### PR DESCRIPTION
GmSSL-Python是走ctypes封装的Python库, 原有描述直接搬了Golang的描述