### PR TITLE
忽略TLS alert_close_notify及warning级别的消息，SM2 模乘运算进一步约减

### DIFF
--- a/src/sm2_alg.c
+++ b/src/sm2_alg.c
@@ -420,12 +420,17 @@ void sm2_fp_mul(SM2_Fp r, const SM2_Fp a, const SM2_Fp b)
 	r[6] = s[6] + s[11] + s[14] + s[15];
 	r[7] = s[7] + s[ 8] + s[ 9] + s[10] + s[11] + s[15] + ((s[12] + s[13] + s[14] + s[15]) << 1);
 
+	u = r[7] >> 32;
+	r[7] = (r[7] & 0xffffffff) + u;
+	r[3] += u;
+	r[0] += u;
+
 	for (i = 1; i < 8; i++) {
 		r[i] += r[i - 1] >> 32;
 		r[i - 1] &= 0xffffffff;
 	}
 
-	d[2] = s[8] + s[9] + s[13] + s[14];
+	d[2] = s[8] + s[9] + s[13] + s[14] + u;
 	d[3] = d[2] >> 32;
 	d[2] &= 0xffffffff;
 	sm2_bn_sub(r, r, d);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -337,7 +337,16 @@ int tls13_do_recv(TLS_CONNECT *conn)
 	tls_trace("decrypt ApplicationData\n");
 	tls_record_trace(stderr, record, tls_record_length(record), 0, 0);
 
-
+	if (record_type == TLS_record_alert) {
+		if (record[5] == TLS_alert_level_warning) {  //level
+			return 0;
+		}
+		if (record[6] == TLS_alert_close_notify) {  //alert
+			return 0;
+		}
+		error_print();
+		return -1;
+	}
 	if (record_type != TLS_record_application_data) {
 		error_print();
 		return -1;


### PR DESCRIPTION
1、TLS1.3客户端在关前，会发送close_notify及user_cancel Alarm消息，服务器会认为异常，修改为忽略此类消息；
2、SM2模乘运算，在进行模约减时，对于最高字节超过32位的部分再约减一次，减后最后的循环次数