### PR TITLE
Fix building issues introduced in "Update sm2 sign/enc with z256 implementation"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ set(src
 	src/sm3_digest.c
 	src/sm2_alg.c
 	src/sm2_key.c
-	src/sm2_z256_sign.c
 	src/sm2_lib.c
 	src/sm2_ctx.c
 	src/sm9_alg.c
@@ -320,8 +319,10 @@ option(ENABLE_SM2_Z256 "Enable SM2 z256 implementation" OFF)
 if (ENABLE_SM2_Z256)
 	message(STATUS "ENABLE_SM2_Z256 is ON")
 	add_definitions(-DENABLE_SM2_Z256)
-	list(APPEND src src/sm2_z256.c src/sm2_z256_table.c)
+	list(APPEND src src/sm2_z256.c src/sm2_z256_sign.c src/sm2_z256_table.c)
 	list(APPEND tests sm2_z256)
+else()
+	list(APPEND src src/sm2_sign.c)
 endif()
 
 

--- a/tests/sm2_signtest.c
+++ b/tests/sm2_signtest.c
@@ -102,6 +102,8 @@ static int test_sm2_do_sign(void)
 	return 1;
 }
 
+#ifdef ENABLE_SM2_Z256
+
 #define SM2_U256		SM2_Z256
 #define sm2_u256_one		sm2_z256_one
 #define sm2_u256_is_zero	sm2_z256_is_zero
@@ -140,6 +142,8 @@ static int test_sm2_do_sign_fast(void)
 	printf("%s() ok\n", __FUNCTION__);
 	return 1;
 }
+
+#endif // ENABLE_SM2_Z256
 
 static int test_sm2_sign(void)
 {


### PR DESCRIPTION
After 4fa09e1f54fd22765c31fd013b24302c31673a0e, building GmSSL with default options (cmake without any -D) results in the following build error:

```
[ 62%] Linking C executable bin/gmssl
/usr/bin/ld: bin/libgmssl.so.3.1: undefined reference to `sm2_z256_modn_add'
/usr/bin/ld: bin/libgmssl.so.3.1: undefined reference to `sm2_z256_modn_rand'
/usr/bin/ld: bin/libgmssl.so.3.1: undefined reference to `sm2_z256_one'
...
```

This happens because sm2_z256_* family was introduced alonsgide the existing sm2_* implementation. While it should be a optional feature with -DENABLE_SM2_Z256 to turn it on/off, in reality sm2_z256_sign.c replaced sm2_sign.c in the src list, so building GmSSL without Z256 feature always results in failure now. (With Z256 enabled, the building issue is gone, but that is only a workaround).

This fixes the issue by add sm2_{,z256_}sign to src list if ENABLE_SM2_Z256 is disabled/enabled, and uses a if check to skip a test function for sm2 that is only buildable when Z256 is enabled.