### PR TITLE
Fix build linking error (When ENABLE_SM2_Z256 is OFF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ set(src
 	src/sm3_digest.c
 	src/sm2_alg.c
 	src/sm2_key.c
-	src/sm2_z256_sign.c
 	src/sm2_lib.c
 	src/sm2_ctx.c
 	src/sm9_alg.c
@@ -320,8 +319,10 @@ option(ENABLE_SM2_Z256 "Enable SM2 z256 implementation" OFF)
 if (ENABLE_SM2_Z256)
 	message(STATUS "ENABLE_SM2_Z256 is ON")
 	add_definitions(-DENABLE_SM2_Z256)
-	list(APPEND src src/sm2_z256.c src/sm2_z256_table.c)
+	list(APPEND src src/sm2_z256.c src/sm2_z256_table.c src/sm2_z256_sign.c)
 	list(APPEND tests sm2_z256)
+else ()
+	list(APPEND src src/sm2_sign.c)
 endif()
 
 


### PR DESCRIPTION
解决当ENABLE_SM2_Z256开关是关闭时，编译时会报错；
编译命令：
cmake .. -DCMAKE_C_STANDARD=99
make -j8

报错信息：
Linking C executable bin/gmssl
bin/libgmssl.so.3.1：对‘sm2_z256_modn_add’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_modn_rand’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_one’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_modn_inv’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_point_mul’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_order’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_to_bytes’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_print’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_is_zero’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_point_is_on_curve’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_cmp’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_add’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_point_to_bytes’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_point_mul_sum’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_modn_mul’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_sub’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_modn_sub’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_point_from_bytes’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_point_mul_generator’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_from_bytes’未定义的引用
bin/libgmssl.so.3.1：对‘sm2_z256_point_get_xy’未定义的引用
collect2: 错误：ld 返回 1
make[2]: *** [CMakeFiles/gmssl-bin.dir/build.make:786：bin/gmssl] 错误 1
make[1]: *** [CMakeFiles/Makefile2:241：CMakeFiles/gmssl-bin.dir/all] 错误 2
make: *** [Makefile:166：all] 错误 2