### PR TITLE
Update sm2_key.c and delete useles var

### DIFF
--- a/src/sm2_key.c
+++ b/src/sm2_key.c
@@ -89,7 +89,6 @@ int sm2_key_print(FILE *fp, int fmt, int ind, const char *label, const SM2_KEY *
 int sm2_public_key_to_der(const SM2_KEY *key, uint8_t **out, size_t *outlen)
 {
 	uint8_t octets[65];
-	size_t len = 0;
 
 	if (!key) {
 		return 0;


### PR DESCRIPTION
to fix error
```
error: ../../common/gmssl/src/sm2_key.c: In function 'sm2_public_key_to_der': ../../common/gmssl/src/sm2_key.c:110:9: error: unused variable 'len' [-Werror=unused-variable]
  size_t len = 0;
         ^~~
cc1: all warnings being treated as errors
```