### PR TITLE
sm4 ccm bug fix

### DIFF
--- a/src/sm4_ccm.c
+++ b/src/sm4_ccm.c
@@ -74,7 +74,7 @@ int sm4_ccm_encrypt(const SM4_KEY *sm4_key, const uint8_t *iv, size_t ivlen,
 	}
 
 	inlen_size = 15 - ivlen;
-	if (inlen_size < 8 && inlen >= ((size_t)1 << (inlen_size * 8))) {
+	if (inlen_size < 8 && inlen >= ((uint64_t)1 << (inlen_size * 8))) {
 		error_print();
 		return -1;
 	}
@@ -109,7 +109,7 @@ int sm4_ccm_encrypt(const SM4_KEY *sm4_key, const uint8_t *iv, size_t ivlen,
 		}
 		sm4_cbc_mac_update(&mac_ctx, block, alen);
 		sm4_cbc_mac_update(&mac_ctx, aad, aadlen);
-		if (alen + aadlen % 16) {
+		if ((alen + aadlen) % 16) {
 			sm4_cbc_mac_update(&mac_ctx, zeros, 16 - (alen + aadlen)%16);
 		}
 	}
@@ -159,7 +159,7 @@ int sm4_ccm_decrypt(const SM4_KEY *sm4_key, const uint8_t *iv, size_t ivlen,
 	}
 
 	inlen_size = 15 - ivlen;
-	if (inlen_size < 8 && inlen >= (size_t)(1 << (inlen_size * 8))) {
+	if (inlen_size < 8 && inlen >= (uint64_t)(1 << (inlen_size * 8))) {
 		error_print();
 		return -1;
 	}
@@ -194,7 +194,7 @@ int sm4_ccm_decrypt(const SM4_KEY *sm4_key, const uint8_t *iv, size_t ivlen,
 		}
 		sm4_cbc_mac_update(&mac_ctx, block, alen);
 		sm4_cbc_mac_update(&mac_ctx, aad, aadlen);
-		if (alen + aadlen % 16) {
+		if ((alen + aadlen) % 16) {
 			sm4_cbc_mac_update(&mac_ctx, zeros, 16 - (alen + aadlen)%16);
 		}
 	}


### PR DESCRIPTION
解决了编译为32位程序时，参数校验溢出的问题，解决了CCM在特定参数时，aad数据段多padding了一个block，导致计算tag错误的问题 。