### PR TITLE
Fix SSL 2 version constant to 0x0002

### DIFF
--- a/include/gmssl/tls.h
+++ b/include/gmssl/tls.h
@@ -54,7 +54,7 @@ int tls_length_is_zero(size_t len);
 
 typedef enum {
 	TLS_protocol_tlcp			= 0x0101,
-	TLS_protocol_ssl2			= 0x0200,
+	TLS_protocol_ssl2			= 0x0002,
 	TLS_protocol_ssl3			= 0x0300,
 	TLS_protocol_tls1			= 0x0301,
 	TLS_protocol_tls11			= 0x0302,


### PR DESCRIPTION
SSL 2 uses a version field of 0x0002, not 0x0200.  This is confirmed not only in the original Netscape spec [1] and RFC draft of the time [2], but also in major implementations such as OpenSSL [3] and Wireshark [4].

[1] https://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html
[2] https://datatracker.ietf.org/doc/html/draft-hickman-netscape-ssl-00
[3] https://github.com/openssl/openssl/blob/OpenSSL_0_9_6m/ssl/ssl2.h#L66-L71
[4] https://github.com/wireshark/wireshark/blob/release-4.4/epan/dissectors/packet-tls-utils.h#L266-L277