### PR TITLE
Use `select` call for socket waiting (Fixes #1788)

### DIFF
--- a/include/gmssl/socket.h
+++ b/include/gmssl/socket.h
@@ -36,7 +36,6 @@ typedef int tls_socklen_t;
 #define tls_socket_send(sock,buf,len,flags)	send(sock,buf,(int)(len),flags)
 #define tls_socket_recv(sock,buf,len,flags)	recv(sock,buf,(int)(len),flags)
 #define tls_socket_close(sock)			closesocket(sock)
-#define tls_socket_wait()			Sleep(1)
 
 #else
 
@@ -45,6 +44,7 @@ typedef int tls_socklen_t;
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #include <netinet/in.h>
 #include <unistd.h>
 
@@ -56,7 +56,6 @@ typedef socklen_t tls_socklen_t;
 #define tls_socket_send(sock,buf,len,flags)	send(sock,buf,len,flags)
 #define tls_socket_recv(sock,buf,len,flags)	recv(sock,buf,len,flags)
 #define tls_socket_close(sock)			close(sock)
-#define tls_socket_wait()			usleep(1000)
 
 #endif
 
@@ -67,7 +66,8 @@ int tls_socket_connect(tls_socket_t sock, const struct sockaddr_in *addr);
 int tls_socket_bind(tls_socket_t sock, const struct sockaddr_in *addr);
 int tls_socket_listen(tls_socket_t sock, int backlog);
 int tls_socket_accept(tls_socket_t sock, struct sockaddr_in *addr, tls_socket_t *conn_sock);
-
+int tls_socket_wait_recv(tls_socket_t sock);
+int tls_socket_wait_send(tls_socket_t sock);
 
 #ifdef __cplusplus
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -168,3 +168,21 @@ int tls_socket_accept(tls_socket_t sock, struct sockaddr_in *addr, tls_socket_t 
 	return 1;
 }
 #endif
+
+int tls_socket_wait_recv(tls_socket_t sock)
+{
+	fd_set readfds;
+	FD_ZERO(&readfds);
+	FD_SET(sock, &readfds);
+
+	return select(sock+1, &readfds, NULL, NULL, NULL);
+}
+
+int tls_socket_wait_send(tls_socket_t sock)
+{
+	fd_set writefds;
+	FD_ZERO(&writefds);
+	FD_SET(sock, &writefds);
+
+	return select(sock+1, NULL, &writefds, NULL, NULL);
+}


### PR DESCRIPTION
It eliminates the (perhaps non-blocking version of) speedup loop by using a generic `select` call which should be available both to POSIX and Winsock2.