### PR TITLE
pin dependencies and restrict permissions in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-    - uses: nttld/setup-ndk@v1
+    - uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # v1.5.0
       id: setup-ndk
       with:
         ndk-version: r25

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -10,16 +10,19 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Configure build for x86
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: amd64_x86
         

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,6 +10,9 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
@@ -21,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Get ios-cmake
-      uses: sudosubin/git-clone-action@v1.0.1
+      uses: sudosubin/git-clone-action@8a93ce24d47782e30077508cccacf8a05a891bae # v1.0.1
       with:
         # Repository owner and name. Ex: sudosubin/git-clone-action
         repository: leetal/ios-cmake


### PR DESCRIPTION
Hi. Here are some fixes/changes in workflows. Lack of explicit permission settings may allow a malicious PR to inject malicious code through write permissions in actions. Adding read-only permissions at the top level will help you avoid forgetting permission configurations when adding other jobs next time. I‘d like to say that it won't add any extra burden and will make things easier for you.

Additionally, I pin the dependencies to specific commit hashes. It considers the vulnerability in https://github.com/tj-actions/changed-files/issues/2464 ([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)). But some developers think that it's burden. It's up to you — I can remove them if you prefer. Dependabot can help you avoid manually updating the hash values.