### PR TITLE
fix: off-by-one in asn1_object_identifier_from_octets()

### DIFF
--- a/src/asn1.c
+++ b/src/asn1.c
@@ -1041,7 +1041,7 @@ int asn1_object_identifier_from_octets(uint32_t *nodes, size_t *nodes_cnt, const
 
 	while (inlen) {
 		uint32_t val;
-		if (*nodes_cnt > ASN1_OID_MAX_NODES) {
+		if (*nodes_cnt >= ASN1_OID_MAX_NODES) {
 			error_print();
 			return -1;
 		}


### PR DESCRIPTION
Fix stack buffer overflow when parsing OID with exactly 32 nodes.

The bounds check used `>` instead of `>=`, allowing an out-of-bounds 
write to `nodes[32]` when `nodes_cnt == ASN1_OID_MAX_NODES`.

Fixes #1868 