### PR TITLE
fix(sm2): fix compressed point output writing y instead of x

### DIFF
--- a/src/sm2_z256.c
+++ b/src/sm2_z256.c
@@ -1865,7 +1865,7 @@ int sm2_z256_point_to_compressed_octets(const SM2_Z256_POINT *P, uint8_t out[33]
 	} else {
 		out[0] = SM2_point_compressed_y_even;
 	}
-	sm2_z256_to_bytes(y, out + 1);
+	sm2_z256_to_bytes(x, out + 1);
 
 	return 1;
 }


### PR DESCRIPTION
In sm2_z256_point_to_compressed_octets(), the compressed point format should be: [1-byte flag] + [32-byte x-coordinate]

The flag indicates y's parity (0x02=even, 0x03=odd), but the actual coordinate stored should be x (since y can be recovered from x using the curve equation).

The original code incorrectly wrote y-coordinate instead of x-coordinate.