### PR TITLE
Fix Windows build with Clang/LLVM toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,7 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
-if (CMAKE_C_COMPILER_ID MATCHES "MSVC")
+if (WIN32 AND CMAKE_C_COMPILER_ID MATCHES "MSVC|Clang")
 	message(STATUS "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS")
 	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # set before add_library
 endif()

--- a/include/gmssl/endian.h
+++ b/include/gmssl/endian.h
@@ -11,6 +11,7 @@
 #ifndef GMSSL_ENDIAN_H
 #define GMSSL_ENDIAN_H
 
+#include <stdint.h>
 
 /* Big Endian R/W */
 

--- a/include/gmssl/kyber.h
+++ b/include/gmssl/kyber.h
@@ -94,7 +94,7 @@ void kyber_poly_add(kyber_poly_t r, const kyber_poly_t a, const kyber_poly_t b);
 void kyber_poly_sub(kyber_poly_t r, const kyber_poly_t a, const kyber_poly_t b);
 
 
-int16_t zeta[256];
+extern int16_t zeta[256];
 
 void init_zeta(void);
 

--- a/src/tls12.c
+++ b/src/tls12.c
@@ -23,9 +23,11 @@
 #include <gmssl/mem.h>
 #include <gmssl/tls.h>
 
-#include <fcntl.h>
 #include <errno.h>
+#ifndef WIN32
+#include <fcntl.h>
 #include <sys/select.h>
+#endif
 
 
 

--- a/src/tls_cookie.c
+++ b/src/tls_cookie.c
@@ -23,9 +23,11 @@
 #include <gmssl/mem.h>
 #include <gmssl/tls.h>
 
-#include <fcntl.h>
 #include <errno.h>
+#ifndef WIN32
+#include <fcntl.h>
 #include <sys/select.h>
+#endif
 
 /*
 cookie

--- a/src/tls_ocsp.c
+++ b/src/tls_ocsp.c
@@ -23,9 +23,11 @@
 #include <gmssl/mem.h>
 #include <gmssl/tls.h>
 
-#include <fcntl.h>
 #include <errno.h>
+#ifndef WIN32
+#include <fcntl.h>
 #include <sys/select.h>
+#endif
 
 
 /*

--- a/src/tls_psk.c
+++ b/src/tls_psk.c
@@ -23,9 +23,11 @@
 #include <gmssl/mem.h>
 #include <gmssl/tls.h>
 
-#include <fcntl.h>
 #include <errno.h>
+#ifndef WIN32
+#include <fcntl.h>
 #include <sys/select.h>
+#endif
 
 
 

--- a/src/tls_sct.c
+++ b/src/tls_sct.c
@@ -23,9 +23,11 @@
 #include <gmssl/mem.h>
 #include <gmssl/tls.h>
 
-#include <fcntl.h>
 #include <errno.h>
+#ifndef WIN32
+#include <fcntl.h>
 #include <sys/select.h>
+#endif
 
 
 /*

--- a/src/tls_sni.c
+++ b/src/tls_sni.c
@@ -23,9 +23,11 @@
 #include <gmssl/mem.h>
 #include <gmssl/tls.h>
 
-#include <fcntl.h>
 #include <errno.h>
+#ifndef WIN32
+#include <fcntl.h>
 #include <sys/select.h>
+#endif
 
 /*
 server_name (SNI)


### PR DESCRIPTION
This commit fixes compilation errors when building GmSSL on Windows with clang-cl and ninja.

Changes:

- include/gmssl/endian.h: Add #include <stdint.h> for uint32_t/uint64_t types

- include/gmssl/kyber.h: Add extern to zeta[] declaration to avoid duplicate symbols

- src/tls_*.c (6 files): Guard POSIX headers fcntl.h and sys/select.h with #ifndef WIN32, keep errno.h on all platforms

- CMakeLists.txt: Enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS for MSVC and Clang on Windows, preserving MinGW behavior