### PR TITLE
Avoid sudo during tests run

### DIFF
--- a/cmake/tlcp_commands.cmake
+++ b/cmake/tlcp_commands.cmake
@@ -23,7 +23,7 @@ if(WIN32)
 	)
 else()
 	execute_process(
-		COMMAND bash -c "sudo nohup bin/gmssl tlcp_server -port 4433 -cert tlcp_server_certs.pem -key signkey.pem -pass P@ssw0rd -ex_key enckey.pem -ex_pass P@ssw0rd > tlcp_server.log 2>&1 &"
+		COMMAND bash -c "nohup bin/gmssl tlcp_server -port 4433 -cert tlcp_server_certs.pem -key signkey.pem -pass P@ssw0rd -ex_key enckey.pem -ex_pass P@ssw0rd > tlcp_server.log 2>&1 &"
 		RESULT_VARIABLE SERVER_RESULT
 		TIMEOUT 5
 	)
@@ -57,6 +57,6 @@ if(${FOUND_INDEX} EQUAL -1)
 endif()
 
 execute_process(
-	COMMAND sudo pkill -f "gmssl"
+	COMMAND pkill -f "gmssl"
 )
 

--- a/cmake/tls12_commands.cmake
+++ b/cmake/tls12_commands.cmake
@@ -16,7 +16,7 @@ if(NOT EXISTS enckey.pem)
 endif()
 
 execute_process(
-	COMMAND bash -c "sudo nohup bin/gmssl tls12_server -port 4333 -cert tls_server_certs.pem -key signkey.pem -pass P@ssw0rd > tls12_server.log 2>&1 &"
+	COMMAND bash -c "nohup bin/gmssl tls12_server -port 4333 -cert tls_server_certs.pem -key signkey.pem -pass P@ssw0rd > tls12_server.log 2>&1 &"
 	RESULT_VARIABLE SERVER_RESULT
 	TIMEOUT 5
 )
@@ -40,6 +40,6 @@ if(${FOUND_INDEX} EQUAL -1)
 endif()
 
 execute_process(
-	COMMAND sudo pkill -f "gmssl"
+	COMMAND pkill -f "gmssl"
 )
 

--- a/cmake/tls13_commands.cmake
+++ b/cmake/tls13_commands.cmake
@@ -16,7 +16,7 @@ if(NOT EXISTS enckey.pem)
 endif()
 
 execute_process(
-	COMMAND bash -c "sudo nohup bin/gmssl tls13_server -port 4443 -cert tls_server_certs.pem -key signkey.pem -pass P@ssw0rd > tls13_server.log 2>&1 &"
+	COMMAND bash -c "nohup bin/gmssl tls13_server -port 4443 -cert tls_server_certs.pem -key signkey.pem -pass P@ssw0rd > tls13_server.log 2>&1 &"
 	RESULT_VARIABLE SERVER_RESULT
 	TIMEOUT 5
 )
@@ -40,6 +40,6 @@ if(${FOUND_INDEX} EQUAL -1)
 endif()
 
 execute_process(
-	COMMAND sudo pkill -f "gmssl"
+	COMMAND pkill -f "gmssl"
 )
 


### PR DESCRIPTION
`sudo` is not necessary to start the server. `sudo` also blocks the tests run because of asking for password input.

OS: Fedora.