### PR TITLE
修复 ASN.1 UTF8String 多字节字符校验

### DIFF
--- a/src/asn1.c
+++ b/src/asn1.c
@@ -1281,7 +1281,7 @@ static int asn1_utf8char_from_bytes(uint32_t *c, const uint8_t **pin, size_t *pi
 
 	utf8char = in[0];
 	for (i = 1; i < utf8char_len; i++) {
-		if ((in[i] & 0x60) != 0x80) {
+		if ((in[i] & 0xc0) != 0x80) {
 			//error_print(); // disable error_print for _is_ compare
 			return -1;
 		}

--- a/tests/asn1test.c
+++ b/tests/asn1test.c
@@ -500,7 +500,10 @@ static int test_asn1_utf8_string(void)
 		"hello",
 		"world",
 		"Just do it!",
+		"J\303\274rgen",
+		"\344\270\255",
 	};
+	const char invalid_utf8[] = { (char)0xc3, 'A' };
 	uint8_t buf[256];
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
@@ -527,6 +530,10 @@ static int test_asn1_utf8_string(void)
 		format_string(stderr, 0, 4, "", (uint8_t *)d, dlen);
 	}
 	if (len != 0) {
+		error_print();
+		return -1;
+	}
+	if (asn1_string_is_utf8_string(invalid_utf8, sizeof(invalid_utf8)) != 0) {
 		error_print();
 		return -1;
 	}
@@ -841,6 +848,7 @@ static int test_asn1_from_der_null_args(void)
 int main(void)
 {
 	if (test_asn1_tag() != 1) goto err;
+	if (test_asn1_utf8_string() != 1) goto err;
 /*
 	if (test_asn1_length() != 1) goto err;
 	if (test_asn1_length_from_ber() != 1) goto err;


### PR DESCRIPTION
修复 `asn1_utf8char_from_bytes` 中 UTF-8 continuation byte 掩码错误。

合法 3 字节 UTF-8 字符 `中` 之前会被 `asn1_string_is_utf8_string` 判为无效；修复后可正常通过校验。

修复问题：https://github.com/guanzhi/GmSSL/issues/1894