### PR TITLE
用代码中已有的 constant 时间比较替换 memcmp

### DIFF
--- a/src/aes_modes.c
+++ b/src/aes_modes.c
@@ -215,7 +215,7 @@ int aes_gcm_decrypt(const AES_KEY *key, const uint8_t *iv, size_t ivlen,
 	ghash(H, aad, aadlen, in, inlen, H);
 	aes_encrypt(key, Y, T);
 	gmssl_memxor(T, T, H, taglen);
-	if (memcmp(T, tag, taglen) != 0) {
+	if (gmssl_secure_memcmp(T, tag, taglen) != 0) {
 		error_print();
 		return -1;
 	}

--- a/src/sm2_enc.c
+++ b/src/sm2_enc.c
@@ -352,7 +352,7 @@ int sm2_do_decrypt(const SM2_KEY *key, const SM2_CIPHERTEXT *in, uint8_t *out, s
 	sm3_finish(&sm3_ctx, hash);
 
 	// check if u == C3
-	if (memcmp(in->hash, hash, sizeof(hash)) != 0) {
+	if (gmssl_secure_memcmp(in->hash, hash, sizeof(hash)) != 0) {
 		error_print();
 		goto end;
 	}

--- a/src/sm4_cbc_sm3_hmac.c
+++ b/src/sm4_cbc_sm3_hmac.c
@@ -161,7 +161,7 @@ int sm4_cbc_sm3_hmac_decrypt_finish(SM4_CBC_SM3_HMAC_CTX *ctx, uint8_t *out, siz
 		error_print();
 		return -1;
 	}
-	if (memcmp(mac, ctx->mac, SM3_HMAC_SIZE) != 0) {
+	if (gmssl_secure_memcmp(mac, ctx->mac, SM3_HMAC_SIZE) != 0) {
 		error_print();
 		return -1;
 	}

--- a/src/sm4_ccm.c
+++ b/src/sm4_ccm.c
@@ -216,7 +216,7 @@ int sm4_ccm_decrypt(const SM4_KEY *sm4_key, const uint8_t *iv, size_t ivlen,
 
 	// diff from encrypt
 	gmssl_memxor(mac, mac, block, taglen);
-	if (memcmp(mac, tag, taglen) != 0) {
+	if (gmssl_secure_memcmp(mac, tag, taglen) != 0) {
 		error_print();
 		gmssl_secure_clear(&mac_ctx, sizeof(mac_ctx));
 		return -1;

--- a/src/sm4_ctr_sm3_hmac.c
+++ b/src/sm4_ctr_sm3_hmac.c
@@ -161,7 +161,7 @@ int sm4_ctr_sm3_hmac_decrypt_finish(SM4_CTR_SM3_HMAC_CTX *ctx, uint8_t *out, siz
 		error_print();
 		return -1;
 	}
-	if (memcmp(mac, ctx->mac, SM3_HMAC_SIZE) != 0) {
+	if (gmssl_secure_memcmp(mac, ctx->mac, SM3_HMAC_SIZE) != 0) {
 		error_print();
 		return -1;
 	}

--- a/src/sm4_gcm.c
+++ b/src/sm4_gcm.c
@@ -103,7 +103,7 @@ int sm4_gcm_decrypt(const SM4_KEY *key, const uint8_t *iv, size_t ivlen,
 
 	sm4_encrypt(key, Y, T);
 	gmssl_memxor(T, T, H, taglen);
-	if (memcmp(T, tag, taglen) != 0) {
+	if (gmssl_secure_memcmp(T, tag, taglen) != 0) {
 		error_print();
 		return -1;
 	}
@@ -327,7 +327,7 @@ int sm4_gcm_decrypt_finish(SM4_GCM_CTX *ctx, uint8_t *out, size_t *outlen)
 	}
 
 	gmssl_memxor(mac, mac, ctx->Y, ctx->taglen);
-	if (memcmp(mac, ctx->mac, ctx->taglen) != 0) {
+	if (gmssl_secure_memcmp(mac, ctx->mac, ctx->taglen) != 0) {
 		error_print();
 		return -1;
 	}


### PR DESCRIPTION
把 tag/MAC 校验中的 memcmp 替换为已有的 gmssl_secure_memcmp，防御潜在的侧信道安全问题。

修复问题：https://github.com/guanzhi/GmSSL/issues/1896