### PR TITLE
修复 SDF CBC 流式解密 IV 未更新问题

### DIFF
--- a/src/sdf/sdf.c
+++ b/src/sdf/sdf.c
@@ -291,9 +291,13 @@ static int sdf_cbc_encrypt_blocks(SDF_KEY *key, uint8_t iv[16], const uint8_t *i
 
 static int sdf_cbc_decrypt_blocks(SDF_KEY *key, uint8_t iv[16], const uint8_t *in, size_t nblocks, uint8_t *out)
 {
+	uint8_t last_block[16];
 	unsigned int inlen = (unsigned int)(nblocks * 16);
 	unsigned int outlen = 0;
 
+	if (inlen) {
+		memcpy(last_block, in + inlen - 16, 16);
+	}
 	if (SDF_Decrypt(key->session, key->handle, SGD_SM4_CBC,
 		iv, (unsigned char *)in, inlen, out, &outlen) != SDR_OK) {
 		error_print();
@@ -304,9 +308,7 @@ static int sdf_cbc_decrypt_blocks(SDF_KEY *key, uint8_t iv[16], const uint8_t *i
 		return -1;
 	}
 	if (inlen) {
-		if (memcmp(iv, in + inlen - 16, 16) != 0) {
-			memcmp(iv, in + inlen - 16, 16);
-		}
+		memcpy(iv, last_block, 16);
 	}
 	return 1;
 }


### PR DESCRIPTION

<img width="455" height="367" alt="image" src="https://github.com/user-attachments/assets/87204b9e-7b69-4b80-841f-8e69148ef6cc" />



修复 `sdf_cbc_decrypt_blocks()` 解密后未更新 `IV` 的问题。`CBC` 分块解密完成后，`IV` 应更新为上一批输入密文的最后一个 `block`。

实现上先保存最后一个输入密文块，再调用 `SDF_Decrypt()`，成功后更新 `IV`。

修复问题：https://github.com/guanzhi/GmSSL/issues/1898