### PR TITLE
asm: add missing .note.GNU-stack markers

### DIFF
--- a/src/gf128_arm64.S
+++ b/src/gf128_arm64.S
@@ -99,4 +99,6 @@ func(gf128_mul):
 
 	ret
 
-
+#ifdef __ELF__
+.section .note.GNU-stack,"",@progbits
+#endif

--- a/src/sm2_z256_amd64.S
+++ b/src/sm2_z256_amd64.S
@@ -2139,3 +2139,6 @@ func(sm2_z256_point_add_affine):
 	popq	%rbp
 	.byte	0xf3,0xc3
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",@progbits
+#endif

--- a/src/sm2_z256_arm64.S
+++ b/src/sm2_z256_arm64.S
@@ -2210,3 +2210,6 @@ func(sm2_z256_modn_mont_sqr):
 	ldp	x29,x30,[sp],#64
 	ret
 
+#ifdef __ELF__
+.section .note.GNU-stack,"",@progbits
+#endif

--- a/src/sm9_z256_arm64.S
+++ b/src/sm9_z256_arm64.S
@@ -895,3 +895,6 @@ func(sm9_z256_modp_mont_sqr):
 	ldp	x29,x30,[sp],#64
 	ret
 
+#ifdef __ELF__
+.section .note.GNU-stack,"",@progbits
+#endif


### PR DESCRIPTION
Add .note.GNU-stack section declarations to hand-written assembly sources so ELF builds do not produce executables or libraries with an executable stack.

These assembly implementations do not require an executable stack. Adding the marker restores normal non-executable stack/NX hardening.

Before this patch:

    $ readelf -W -l bin/gmssl | grep GNU_STACK
      GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RWE 0x10

After this patch:

    $ readelf -W -l bin/gmssl | grep GNU_STACK
      GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x10

An executable PT_GNU_STACK weakens standard memory protection by making the process stack executable. While this does not by itself introduce a vulnerability, it reduces NX hardening and can make unrelated memory corruption bugs easier to exploit.