### PR TITLE
修复Linux arm64下链接问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,11 @@ option(ENABLE_GHASH "Enable standalone GHASH command and test" ON)
 option(ENABLE_SKF "Enable SKF module" ON)
 option(ENABLE_SDF "Enable SDF module" ON)
 
-option(ENABLE_ASM_UNDERSCORE_PREFIX "Add prefix `_` to assembly symbols" ON)
+if (APPLE)
+	option(ENABLE_ASM_UNDERSCORE_PREFIX "Add prefix `_` to assembly symbols" ON)
+else()
+	option(ENABLE_ASM_UNDERSCORE_PREFIX "Add prefix `_` to assembly symbols" OFF)
+endif()
 
 option(ENABLE_TLS "Enable TLS and TLCP protocol support" ON)
 option(ENABLE_QUIC "Enable QUIC support" ON)


### PR DESCRIPTION
ENABLE_ASM_UNDERSCORE_PREFIX 适用于APPLE, 在Linux 上编译时需关闭 ENABLE_ASM_UNDERSCORE_PREFIX选项，错误日志见附件
[GmSSL-link-error.log](https://github.com/user-attachments/files/29449984/GmSSL-link-error.log)
