### PR TITLE
修复 tool_tls13_sm4_gcm_client_cert — TLS 1.3 客户端证书选择 bug

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5874,9 +5874,9 @@ int tls13_recv_certificate_request(TLS_CONNECT *conn)
 	int signed_certificate_timestamp = 0;
 
 	int common_sig_algs[4];
-	size_t common_sig_algs_cnt;
+	size_t common_sig_algs_cnt = 0;
 	int common_sig_algs_cert[4];
-	size_t common_sig_algs_cert_cnt;
+	size_t common_sig_algs_cert_cnt = 0;
 	const uint8_t *ca_names = NULL;
 	size_t ca_names_len = 0;
 	const uint8_t *filters = NULL;


### PR DESCRIPTION
make test时报 91 - tool_tls13_sm4_gcm_client_cert (Failed) 详细日志见附件
[GmSSL-make-test-error.log](https://github.com/user-attachments/files/29452791/GmSSL-make-test-error.log)

 在 tls13_recv_certificate_request() 中，common_sig_algs_cert_cnt 未初始化。当服务端未发送 signature_algorithms_cert 扩展时，该变量可能是随机非零值。

tls_cert_chain_match_extensions() 的判断是：

if (signature_algorithms_cert && signature_algorithms_cert_cnt)
由于 common_sig_algs_cert 是栈上数组，指针始终非空，随机非零的 cnt 会误触发证书链校验，导致客户端无法选出证书、发送空 Certificate，服务端随后拒绝连接。