### PR TITLE
修复 tool_pqc — XMSS 类型名错误

### DIFF
--- a/cmake/tool_pqc.cmake
+++ b/cmake/tool_pqc.cmake
@@ -21,9 +21,9 @@ endif()
 
 if(ENABLE_XMSS)
 	gmssl_signature_roundtrip(tool_xmss xmsskeygen xmsssign xmssverify
-		KEYGEN_ARGS -xmss_type XMSS_SHA2_10_256)
+		KEYGEN_ARGS -xmss_type XMSS_SM3_10_256)
 	gmssl_signature_roundtrip(tool_xmssmt xmssmtkeygen xmssmtsign xmssmtverify
-		KEYGEN_ARGS -xmssmt_type XMSSMT_SHA2_20_2_256)
+		KEYGEN_ARGS -xmssmt_type XMSSMT_SM3_20_2_256)
 endif()
 
 if(ENABLE_SPHINCS)


### PR DESCRIPTION
测试脚本使用了类型名 XMSS_SHA2_10_256 / XMSSMT_SHA2_20_2_256，而当前工具只支持 SM3 变体。

修改（cmake/tool_pqc.cmake）：

XMSS_SHA2_10_256 → XMSS_SM3_10_256
XMSSMT_SHA2_20_2_256 → XMSSMT_SM3_20_2_256