### PR TITLE
Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,18 @@ include_directories(include)
 if(MSVC)
 	#add_compile_options(/O2) # conflict with CI /0d (not optimized)
 else()
-	add_compile_options(-O3)
+	add_compile_options(-Wall -Wextra -O3)
+	add_compile_options(
+		-Wno-unused-parameter
+		-Wno-missing-field-initializers
+		-Wno-unused-variable
+		-Wno-unused-function
+		-Wno-empty-body
+		-Wno-unused-but-set-variable
+	)
+	if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+		add_compile_options(-Wno-misleading-indentation)
+	endif()
 endif()
 
 set(GMSSL_TARGET_PROCESSOR "${CMAKE_SYSTEM_PROCESSOR}")

--- a/src/asn1.c
+++ b/src/asn1.c
@@ -853,7 +853,7 @@ int asn1_bits_from_der_ex(int tag, int *bits, const uint8_t **in, size_t *inlen)
 {
 	int ret;
 	const uint8_t *p;
-	uint8_t c;
+	uint8_t c = 0;
 	size_t nbits;
 	size_t i;
 

--- a/src/kyber.c
+++ b/src/kyber.c
@@ -331,7 +331,7 @@ int16_t zeta[256];
 
 void init_zeta(void)
 {
-	int i;
+	size_t i;
 
 	zeta[0] = 1;
 	for (i = 1; i < sizeof(zeta)/sizeof(zeta[0]); i++) {

--- a/src/quic.c
+++ b/src/quic.c
@@ -382,7 +382,7 @@ int quic_frame_print(FILE *fp, int fmt, int ind, int level, const uint8_t **in, 
 		{
 			uint64_t offset;
 			uint64_t data_len;
-			const uint8_t *data;
+			const uint8_t *data = NULL;
 			if (quic_varint_from_bytes(&offset, &p, &len) != 1 || quic_varint_from_bytes(&data_len, &p, &len) != 1) return -1;
 			if (data_len > len || quic_bytes_get(&p, &len, &data, (size_t)data_len) != 1) return -1;
 			format_print(fp, fmt, ind, "Offset: %" PRIu64 "\n", offset);
@@ -392,7 +392,7 @@ int quic_frame_print(FILE *fp, int fmt, int ind, int level, const uint8_t **in, 
 		break;
 	case QUIC_frame_new_token:
 		{
-			const uint8_t *token;
+			const uint8_t *token = NULL;
 			if (quic_varint_from_bytes(&val, &p, &len) != 1 || val > len || quic_bytes_get(&p, &len, &token, (size_t)val) != 1) return -1;
 			format_bytes(fp, fmt, ind, "Token", token, (size_t)val);
 		}
@@ -418,8 +418,8 @@ int quic_frame_print(FILE *fp, int fmt, int ind, int level, const uint8_t **in, 
 		{
 			uint64_t seq;
 			uint64_t retire_prior_to;
-			const uint8_t *cid;
-			const uint8_t *token;
+			const uint8_t *cid = NULL;
+			const uint8_t *token = NULL;
 			if (quic_varint_from_bytes(&seq, &p, &len) != 1 || quic_varint_from_bytes(&retire_prior_to, &p, &len) != 1) return -1;
 			if (!len) return -1;
 			val = *p++;
@@ -434,7 +434,7 @@ int quic_frame_print(FILE *fp, int fmt, int ind, int level, const uint8_t **in, 
 	case QUIC_frame_path_challenge:
 	case QUIC_frame_path_response:
 		{
-			const uint8_t *data;
+			const uint8_t *data = NULL;
 			if (quic_bytes_get(&p, &len, &data, 8) != 1) return -1;
 			format_bytes(fp, fmt, ind, "Data", data, 8);
 		}
@@ -443,7 +443,7 @@ int quic_frame_print(FILE *fp, int fmt, int ind, int level, const uint8_t **in, 
 	case QUIC_frame_connection_close_app:
 		{
 			uint64_t reason_len;
-			const uint8_t *reason;
+			const uint8_t *reason = NULL;
 			if (quic_varint_from_bytes(&val, &p, &len) != 1) return -1;
 			format_print(fp, fmt, ind, "Error Code: %" PRIu64 "\n", val);
 			if (type == QUIC_frame_connection_close) {
@@ -459,7 +459,7 @@ int quic_frame_print(FILE *fp, int fmt, int ind, int level, const uint8_t **in, 
 			uint64_t stream_id;
 			uint64_t offset = 0;
 			uint64_t data_len;
-			const uint8_t *data;
+			const uint8_t *data = NULL;
 			if (quic_varint_from_bytes(&stream_id, &p, &len) != 1) return -1;
 			if (type & 0x04) {
 				if (quic_varint_from_bytes(&offset, &p, &len) != 1) return -1;
@@ -569,7 +569,7 @@ int quic_packet_print(FILE *fp, int fmt, int ind, const uint8_t *packet, size_t 
 		}
 
 		if (type == QUIC_packet_initial) {
-			const uint8_t *token;
+			const uint8_t *token = NULL;
 			if (quic_varint_from_bytes(&val, &p, &len) != 1 || val > len || quic_bytes_get(&p, &len, &token, (size_t)val) != 1) return -1;
 			format_bytes(fp, fmt, ind, "Token", token, (size_t)val);
 		}

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -137,7 +137,7 @@ void sha1_update(SHA1_CTX *ctx, const unsigned char *data, size_t datalen)
 	}
 }
 
-void sha1_finish(SHA1_CTX *ctx, unsigned char *dgst)
+void sha1_finish(SHA1_CTX *ctx, uint8_t dgst[SHA1_DIGEST_SIZE])
 {
 	int i;
 

--- a/src/skf/skf_prn.c
+++ b/src/skf/skf_prn.c
@@ -271,7 +271,7 @@ ULONG DEVAPI SKF_GetAlgorName(ULONG ulAlgID, LPSTR *szName)
 {
 	char *name;
 	if ((name = skf_algor_name(ulAlgID)) != NULL) {
-		*szName = (LPSTR)&name;
+		*szName = (LPSTR)name;
 		return SAR_OK;
 	}
 	return SAR_FAIL;

--- a/src/sm2_enc.c
+++ b/src/sm2_enc.c
@@ -276,7 +276,7 @@ retry:
 		size_t len = 0;
 		asn1_integer_to_der(out->point.x, 32, NULL, &len);
 		asn1_integer_to_der(out->point.y, 32, NULL, &len);
-		if (len != point_size) {
+		if (len != (size_t)point_size) {
 			trys--;
 			goto retry;
 		}

--- a/src/sm2_z256.c
+++ b/src/sm2_z256.c
@@ -1404,7 +1404,7 @@ void sm2_z256_point_mul_pre_compute(const SM2_Z256_POINT *P, SM2_Z256_POINT T[16
 	}
 }
 
-void sm2_z256_point_mul_ex(SM2_Z256_POINT *R, const uint64_t k[4], const SM2_Z256_POINT *T)
+void sm2_z256_point_mul_ex(SM2_Z256_POINT *R, const sm2_z256_t k, const SM2_Z256_POINT T[16])
 {
 	int window_size = 5;
 	int R_infinity = 1;

--- a/src/sm3_sse.c
+++ b/src/sm3_sse.c
@@ -226,7 +226,7 @@ void sm3_update(SM3_CTX *ctx, const uint8_t *data, size_t data_len)
 	}
 }
 
-void sm3_finish(SM3_CTX *ctx, uint8_t *digest)
+void sm3_finish(SM3_CTX *ctx, uint8_t dgst[SM3_DIGEST_SIZE])
 {
 	int i;
 
@@ -245,7 +245,7 @@ void sm3_finish(SM3_CTX *ctx, uint8_t *digest)
 
 	sm3_compress_blocks(ctx->digest, ctx->block, 1);
 	for (i = 0; i < 8; i++) {
-		PUTU32(digest + i*4, ctx->digest[i]);
+		PUTU32(dgst + i*4, ctx->digest[i]);
 	}
 }
 

--- a/src/sm4_cfb.c
+++ b/src/sm4_cfb.c
@@ -20,6 +20,11 @@ void sm4_cfb_encrypt(const SM4_KEY *key, size_t sbytes, uint8_t iv[16],
 	uint8_t block[16];
 	size_t len, i;
 
+	if (sbytes == 0 || sbytes > 16) {
+		error_print();
+		return;
+	}
+
 	while (inlen) {
 		len = inlen < sbytes ? inlen : sbytes;
 
@@ -44,6 +49,11 @@ void sm4_cfb_decrypt(const SM4_KEY *key, size_t sbytes, uint8_t iv[16],
 {
 	uint8_t block[16];
 	size_t len, i;
+
+	if (sbytes == 0 || sbytes > 16) {
+		error_print();
+		return;
+	}
 
 	while (inlen) {
 		len = inlen < sbytes ? inlen : sbytes;

--- a/src/sm4_ff1.c
+++ b/src/sm4_ff1.c
@@ -86,7 +86,11 @@ static int sm4_ff1_check_args(const SM4_KEY *key, const char *in, size_t inlen,
 		error_print();
 		return -1;
 	}
-	if (tweaklen < SM4_FF1_MIN_TWEAK_SIZE || tweaklen > SM4_FF1_MAX_TWEAK_SIZE) {
+	if (tweaklen > SM4_FF1_MAX_TWEAK_SIZE
+#if SM4_FF1_MIN_TWEAK_SIZE > 0
+		|| tweaklen < SM4_FF1_MIN_TWEAK_SIZE
+#endif
+	) {
 		error_print();
 		return -1;
 	}

--- a/src/sm9_z256.c
+++ b/src/sm9_z256.c
@@ -354,7 +354,7 @@ int sm9_z256_get_booth(const uint64_t a[4], uint64_t window_size, int i)
 	j = j % 64;
 
 	wbits = a[n] >> j;
-	if ((64 - j) < (window_size + 1) && n < 3) {
+	if ((uint64_t)(64 - j) < (window_size + 1) && n < 3) {
 		wbits |= a[n + 1] << (64 - j);
 	}
 	return (int)(wbits & mask) - (int)((wbits >> 1) & mask);

--- a/src/tls.c
+++ b/src/tls.c
@@ -1151,7 +1151,7 @@ int tls_client_verify_finish(TLS_CLIENT_VERIFY_CTX *ctx, const uint8_t *sig, siz
 void tls_client_verify_cleanup(TLS_CLIENT_VERIFY_CTX *ctx)
 {
 	if (ctx) {
-		int i;
+		TLS_CLIENT_VERIFY_INDEX i;
 		for (i = 0; i< ctx->index; i++) {
 			if (ctx->handshake[i]) {
 				free(ctx->handshake[i]);
@@ -1538,8 +1538,11 @@ int tls_record_get_handshake_client_hello(const uint8_t *record,
 
 	if (*session_id) {
 		if (*session_id_len == 0
+			|| *session_id_len > TLS_MAX_SESSION_ID_SIZE
+#if TLS_MIN_SESSION_ID_SIZE > 0
 			|| *session_id_len < TLS_MIN_SESSION_ID_SIZE
-			|| *session_id_len > TLS_MAX_SESSION_ID_SIZE) {
+#endif
+		) {
 			error_print();
 			return -1;
 		}
@@ -1668,9 +1671,12 @@ int tls_record_get_handshake_server_hello(const uint8_t *record,
 	*protocol = ver;
 
 	if (*session_id) {
-		if (*session_id == 0
+		if (*session_id_len == 0
+			|| *session_id_len > TLS_MAX_SESSION_ID_SIZE
+#if TLS_MIN_SESSION_ID_SIZE > 0
 			|| *session_id_len < TLS_MIN_SESSION_ID_SIZE
-			|| *session_id_len > TLS_MAX_SESSION_ID_SIZE) {
+#endif
+		) {
 			error_print();
 			return -1;
 		}

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4966,11 +4966,11 @@ int tls13_recv_server_hello(TLS_CONNECT *conn)
 	size_t extslen;
 
 	const uint8_t *supported_versions = NULL;
-	size_t supported_versions_len;
+	size_t supported_versions_len = 0;
 	const uint8_t *key_share = NULL;
-	size_t key_share_len;
+	size_t key_share_len = 0;
 	const uint8_t *pre_shared_key = NULL;
-	size_t pre_shared_key_len;
+	size_t pre_shared_key_len = 0;
 
 	int selected_version;
 	int server_key_exchange_mode = 0;
@@ -5627,7 +5627,7 @@ int tls_cert_chain_match_signature_algorithms_cert(
 	int sig_alg;
 
 	if (!cert_chain || !cert_chain_len
-		|| !signature_algorithms_cert && signature_algorithms_cert_cnt) {
+		|| (!signature_algorithms_cert && signature_algorithms_cert_cnt)) {
 		error_print();
 		return -1;
 	}
@@ -5863,13 +5863,13 @@ int tls13_recv_certificate_request(TLS_CONNECT *conn)
 
 	// extensions
 	const uint8_t *signature_algorithms = NULL;
-	size_t signature_algorithms_len;
+	size_t signature_algorithms_len = 0;
 	const uint8_t *signature_algorithms_cert = NULL;
-	size_t signature_algorithms_cert_len;
+	size_t signature_algorithms_cert_len = 0;
 	const uint8_t *certificate_authorities = NULL;
-	size_t certificate_authorities_len;
+	size_t certificate_authorities_len = 0;
 	const uint8_t *oid_filters = NULL;
-	size_t oid_filters_len;
+	size_t oid_filters_len = 0;
 	int status_request = 0;
 	int signed_certificate_timestamp = 0;
 
@@ -6744,27 +6744,27 @@ int tls13_recv_client_hello(TLS_CONNECT *conn)
 
 	// extensions
 	const uint8_t *supported_versions = NULL;
-	size_t supported_versions_len;
+	size_t supported_versions_len = 0;
 	const uint8_t *supported_groups = NULL;
-	size_t supported_groups_len;
+	size_t supported_groups_len = 0;
 	const uint8_t *signature_algorithms = NULL;
-	size_t signature_algorithms_len;
+	size_t signature_algorithms_len = 0;
 	const uint8_t *signature_algorithms_cert = NULL;
-	size_t signature_algorithms_cert_len;
+	size_t signature_algorithms_cert_len = 0;
 	const uint8_t *certificate_authorities = NULL;
-	size_t certificate_authorities_len;
+	size_t certificate_authorities_len = 0;
 	const uint8_t *key_share = NULL;
-	size_t key_share_len;
+	size_t key_share_len = 0;
 	const uint8_t *server_name = NULL;
-	size_t server_name_len;
+	size_t server_name_len = 0;
 	const uint8_t *alpn = NULL;
-	size_t alpn_len;
+	size_t alpn_len = 0;
 	const uint8_t *psk_key_exchange_modes = NULL;
-	size_t psk_key_exchange_modes_len;
+	size_t psk_key_exchange_modes_len = 0;
 	const uint8_t *pre_shared_key = NULL;
-	size_t pre_shared_key_len;
+	size_t pre_shared_key_len = 0;
 	const uint8_t *status_request = NULL;
-	size_t status_request_len;
+	size_t status_request_len = 0;
 	int signed_certificate_timestamp = 0;
 	int early_data = 0;
 
@@ -6778,7 +6778,7 @@ int tls13_recv_client_hello(TLS_CONNECT *conn)
 	size_t common_sig_algs_cert_cnt = 0;
 
 	const uint8_t *host_name = NULL;
-	size_t host_name_len;
+	size_t host_name_len = 0;
 
 	int common_key_exchange_modes = 0;
 
@@ -8015,7 +8015,7 @@ int tls13_recv_client_hello_again(TLS_CONNECT *conn)
 	// pre_shared_key
 	if (pre_shared_key) {
 		if (conn->key_exchange_modes & (TLS_KE_PSK_DHE|TLS_KE_PSK)) {
-			size_t selected_psk_identity = conn->selected_psk_identity;
+			int selected_psk_identity = conn->selected_psk_identity;
 			conn->selected_psk_identity = 0;
 
 			if (conn->psk_identities_len) {

--- a/src/tls_cert.c
+++ b/src/tls_cert.c
@@ -608,8 +608,6 @@ int tls12_cert_chains_select(const uint8_t *cert_chains, size_t cert_chains_len,
 	for (i = 1; cert_chains_len; i++) {
 		const uint8_t *cert_chain;
 		size_t cert_chain_len;
-		int sig_alg;
-		int ret;
 
 		if (tls_uint24array_from_bytes(&cert_chain, &cert_chain_len,
 			&cert_chains, &cert_chains_len) != 1) {
@@ -620,7 +618,8 @@ int tls12_cert_chains_select(const uint8_t *cert_chains, size_t cert_chains_len,
 		if (certs) *certs = cert_chain;
 		if (certs_len) *certs_len = cert_chain_len;
 		if (certs_idx) *certs_idx = i;
-		if (prefered_sig_alg) *prefered_sig_alg = sig_alg;
+		/* prefered_sig_alg extraction not yet implemented */
+		if (prefered_sig_alg) *prefered_sig_alg = 0;
 		return 1;
 	}
 

--- a/src/x509_cer.c
+++ b/src/x509_cer.c
@@ -1810,9 +1810,9 @@ int x509_certs_get_cert_by_issuer_and_serial_number(const uint8_t *d, size_t dle
 int x509_cert_check(const uint8_t *cert, size_t certlen, int cert_type)
 {
 	int version;
-	const uint8_t *serial;
-	size_t serial_len;
-	int tbs_sig_algor;
+	const uint8_t *serial = NULL;
+	size_t serial_len = 0;
+	int tbs_sig_algor = 0;
 	const uint8_t *issuer;
 	size_t issuer_len;
 	time_t not_before;
@@ -1822,7 +1822,7 @@ int x509_cert_check(const uint8_t *cert, size_t certlen, int cert_type)
 	size_t subject_len;
 	const uint8_t *exts;
 	size_t extslen;
-	int sig_algor;
+	int sig_algor = 0;
 
 	if (x509_cert_get_details(cert, certlen,
 		&version, // version

--- a/src/x509_new.c
+++ b/src/x509_new.c
@@ -35,11 +35,23 @@ int x509_cert_new_from_file(uint8_t **out, size_t *outlen, const char *file)
 	size_t fsize;
 	uint8_t *buf = NULL;
 	size_t buflen;
+	size_t q, r;
 
 	if (!(fp = fopen(file, "r"))
-		|| file_size(fp, &fsize) != 1
-		|| (buflen = (fsize * 3)/4 + 1) < 0
-		|| (buf = malloc((fsize * 3)/4 + 1)) == NULL) {
+		|| file_size(fp, &fsize) != 1) {
+		error_print();
+		goto end;
+	}
+	q = fsize / 4;
+	r = fsize % 4;
+	if (q > (SIZE_MAX - 3) / 3) {
+		error_print();
+		goto end;
+	}
+	/* buflen = q*3 + (r*3)/4 + 1, where r <= 3, so tail + 1 <= 3 */
+	buflen = q * 3 + (r * 3) / 4 + 1;
+	buf = malloc(buflen);
+	if (!buf) {
 		error_print();
 		goto end;
 	}
@@ -63,11 +75,23 @@ int x509_certs_new_from_file(uint8_t **out, size_t *outlen, const char *file)
 	size_t fsize;
 	uint8_t *buf = NULL;
 	size_t buflen;
+	size_t q, r;
 
 	if (!(fp = fopen(file, "r"))
-		|| file_size(fp, &fsize) != 1
-		|| (buflen = (fsize * 3)/4 + 1) < 0
-		|| (buf = malloc((fsize * 3)/4 + 1)) == NULL) {
+		|| file_size(fp, &fsize) != 1) {
+		error_print();
+		goto end;
+	}
+	q = fsize / 4;
+	r = fsize % 4;
+	if (q > (SIZE_MAX - 3) / 3) {
+		error_print();
+		goto end;
+	}
+	/* buflen = q*3 + (r*3)/4 + 1, where r <= 3, so tail + 1 <= 3 */
+	buflen = q * 3 + (r * 3) / 4 + 1;
+	buf = malloc(buflen);
+	if (!buf) {
 		error_print();
 		goto end;
 	}

--- a/src/xmss.c
+++ b/src/xmss.c
@@ -1712,7 +1712,7 @@ int xmssmt_key_generate_ex(XMSSMT_KEY *key, uint32_t xmssmt_type,
 	uint32_t layer;
 	xmss_adrs_t adrs;
 	xmss_sm3_digest_t *tree;
-	uint8_t *xmss_root;
+	uint8_t *xmss_root = NULL;
 
 
 	uint64_t index = 0;

--- a/src/zuc.c
+++ b/src/zuc.c
@@ -144,10 +144,10 @@ static const uint8_t S1[256] = {
 			S1[V & 0xFF])
 
 #define F(X0,X1,X2)					\
-	(X0 ^ R1) + R2;					\
+	(((X0) ^ R1) + R2);				\
 	F_(X1, X2)
 
-void zuc_init(ZUC_STATE *state, const uint8_t *user_key, const uint8_t *iv)
+void zuc_init(ZUC_STATE *state, const uint8_t key[ZUC_KEY_SIZE], const uint8_t iv[ZUC_IV_SIZE])
 {
 	ZUC_UINT31 *LFSR = state->LFSR;
 	uint32_t R1, R2;
@@ -157,7 +157,7 @@ void zuc_init(ZUC_STATE *state, const uint8_t *user_key, const uint8_t *iv)
 
 
 	for (i = 0; i < 16; i++) {
-		LFSR[i] = MAKEU31(user_key[i], KD[i], iv[i]);
+		LFSR[i] = MAKEU31(key[i], KD[i], iv[i]);
 	}
 
 	R1 = 0;

--- a/tests/aestest.c
+++ b/tests/aestest.c
@@ -352,7 +352,7 @@ int test_aes_gcm(void)
 	uint8_t out[64];
 	uint8_t tag[16];
 	uint8_t buf[64];
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(aes_gcm_tests)/sizeof(aes_gcm_tests[0]); i++) {
 		hex_to_bytes(aes_gcm_tests[i].K, strlen(aes_gcm_tests[i].K), K, &Klen);
@@ -365,7 +365,7 @@ int test_aes_gcm(void)
 		aes_set_encrypt_key(&aes_key, K, Klen);
 		aes_gcm_encrypt(&aes_key, IV, IVlen, A, Alen, P, Plen, out, Tlen, tag);
 
-		printf("aes gcm test %d ", i + 1);
+		printf("aes gcm test %zu ", i + 1);
 		if (aes_gcm_decrypt(&aes_key, IV, IVlen, A, Alen, out, Plen, tag, Tlen, buf) != 1
 			|| memcmp(buf, P, Plen) != 0) {
 			printf("failed\n");

--- a/tests/asn1test.c
+++ b/tests/asn1test.c
@@ -748,7 +748,7 @@ static int test_asn1_time(void)
 	time_t cur = time(NULL);
 	time_t ts;
 	char str[16] = {0};
-	int i;
+	size_t i;
 
 	if (asn1_time_to_str(0, cur, str) != 1
 		|| asn1_time_from_str(0, &ts, str) != 1

--- a/tests/cmstest.c
+++ b/tests/cmstest.c
@@ -34,7 +34,7 @@ static int test_cms_content_type(void)
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
 		if (cms_content_type_to_der(tests[i], &p, &len) != 1) {

--- a/tests/ectest.c
+++ b/tests/ectest.c
@@ -30,7 +30,7 @@ static int test_ec_named_curve(void)
 		"secp521r1",
 	};
 	int oid;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(curves)/sizeof(curves[0]); i++) {
 		if ((oid = ec_named_curve_from_name(curves[i])) == OID_undef) {

--- a/tests/gf128test.c
+++ b/tests/gf128test.c
@@ -104,7 +104,7 @@ int test_gf128_from_hex(void)
 		"14b267838ec9ef1bb7b5ce8c19e34bc6",
 	};
 	gf128_t a;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
 		gf128_from_hex(a, tests[i]);
@@ -129,7 +129,7 @@ int test_gf128_mul_by_2(void)
 		"8e1807c980d24cd4b2fc5fb3bf4cf406",
 	};
 	gf128_t a;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
 		gf128_from_hex(a, tests[i]);

--- a/tests/ghashtest.c
+++ b/tests/ghashtest.c
@@ -92,7 +92,7 @@ int test_ghash(void)
 	uint8_t T[16];
 	uint8_t out[16];
 	size_t Hlen, Alen, Clen, Tlen;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(ghash_tests)/sizeof(ghash_tests[0]); i++) {
 		hex_to_bytes(ghash_tests[i].H, strlen(ghash_tests[i].H), H, &Hlen);
@@ -162,7 +162,7 @@ static int speed_ghash(void)
 	uint8_t ghash[16];
 	clock_t start, end;
 	double seconds;
-	int i;
+	size_t i;
 
 	ghash_init(&ghash_ctx, h, aad, sizeof(aad));
 	for (i = 0; i < 4096; i++) {

--- a/tests/hkdftest.c
+++ b/tests/hkdftest.c
@@ -193,7 +193,7 @@ static struct {
 
 static int test_hkdf(void)
 {
-	int i;
+	size_t i;
 	const DIGEST *digest;
 	uint8_t ikm[512];
 	uint8_t salt[512];
@@ -221,7 +221,7 @@ static int test_hkdf(void)
 		okmlen = strlen(hkdf_tests[i].okm)/2;
 		L = hkdf_tests[i].L;
 
-		printf("test %d\n", i + 1);
+		printf("test %zu\n", i + 1);
 		format_print(stdout, 0, 0, "Hash = %s\n", digest_name(digest));
 		format_bytes(stdout, 0, 0, "IKM  = ", ikm, ikmlen);
 		format_bytes(stdout, 0, 0, "salt = ", salt, saltlen);
@@ -313,7 +313,7 @@ static int test_sm3_hkdf(void)
 		},
 	};
 
-	int i;
+	size_t i;
 	uint8_t ikm[512];
 	uint8_t salt[512];
 	uint8_t info[512];

--- a/tests/sm2_enctest.c
+++ b/tests/sm2_enctest.c
@@ -278,7 +278,7 @@ static int test_sm2_encrypt(void)
 		SM2_MAX_PLAINTEXT_SIZE,
 	};
 	size_t clen, mlen;
-	int i;
+	size_t i;
 
 	if (sm2_key_generate(&sm2_key) != 1) {
 		error_print();
@@ -324,7 +324,7 @@ static int speed_sm2_encrypt_ctx(void)
 	size_t ciphertext_len;
 	clock_t begin, end;
 	double seconds;
-	int i;
+	size_t i;
 
 	sm2_key_generate(&sm2_key);
 

--- a/tests/sm3test.c
+++ b/tests/sm3test.c
@@ -159,7 +159,7 @@ static int test_sm3(void)
 		sm3_finish(&sm3_ctx, dgst);
 
 		if (memcmp(dgstbuf, dgst, sizeof(dgst)) != 0) {
-			int n;
+			size_t n;
 			fprintf(stderr, "sm3 test %zu failed\n", i+1);
 			fprintf(stderr, "error calculating SM3 on %s\n", testhex[i]);
 			fprintf(stderr, " digest(error) = ");
@@ -183,7 +183,7 @@ static int speed_sm3(void)
 	uint8_t dgst[32];
 	clock_t start, end;
 	double seconds;
-	int i;
+	size_t i;
 
 	for (i = 0; i < 4096; i++) {
 		sm3_update(&sm3_ctx, blocks, sizeof(blocks));

--- a/tests/sm4_cbctest.c
+++ b/tests/sm4_cbctest.c
@@ -393,7 +393,7 @@ static int test_sm4_cbc_ctx(void)
 	uint8_t *out;
 	size_t len;
 	size_t lens[] = { 1,5,17,80 };
-	int i;
+	size_t i;
 
 	rand_bytes(key, sizeof(key));
 	rand_bytes(iv, sizeof(iv));

--- a/tests/sm4_ctrtest.c
+++ b/tests/sm4_ctrtest.c
@@ -341,7 +341,7 @@ static int test_sm4_ctr_ctx_multi_updates(void)
 	size_t len;
 	size_t lens[] = { 1,5,17,80 };
 
-	int i;
+	size_t i;
 
 	rand_bytes(key, sizeof(key));
 	rand_bytes(iv, sizeof(iv));

--- a/tests/sphincstest.c
+++ b/tests/sphincstest.c
@@ -132,8 +132,8 @@ static int test_sphincs_wots_chain(void)
 static int test_sphincs_wots_sk_to_pk(void)
 {
 	sphincs_wots_key_t wots_sk;
-	sphincs_hash128_t seed;
-	sphincs_adrs_t adrs;
+	sphincs_hash128_t seed = {0};
+	sphincs_adrs_t adrs = {0};
 	sphincs_wots_key_t wots_pk;
 
 	sphincs_wots_sk_to_pk(wots_sk, seed, adrs, wots_pk);
@@ -147,8 +147,8 @@ static int test_sphincs_wots_sk_to_pk(void)
 static int test_sphincs_wots_pk_to_root(void)
 {
 	sphincs_wots_key_t wots_pk;
-	sphincs_hash128_t seed;
-	sphincs_adrs_t adrs;
+	sphincs_hash128_t seed = {0};
+	sphincs_adrs_t adrs = {0};
 	sphincs_hash128_t wots_root;
 
 	sphincs_wots_pk_to_root(wots_pk, seed, adrs, wots_root);
@@ -160,9 +160,9 @@ static int test_sphincs_wots_pk_to_root(void)
 static int test_sphincs_wots_sign(void)
 {
 	sphincs_wots_key_t wots_sk;
-	sphincs_hash128_t seed;
-	sphincs_adrs_t adrs;
-	sphincs_hash128_t dgst;
+	sphincs_hash128_t seed = {0};
+	sphincs_adrs_t adrs = {0};
+	sphincs_hash128_t dgst = {0};
 	sphincs_wots_sig_t wots_sig;
 	clock_t start = clock();
 
@@ -176,9 +176,9 @@ static int test_sphincs_wots_sign(void)
 static int test_sphincs_wots_sig_to_pk(void)
 {
 	sphincs_wots_sig_t wots_sig;
-	sphincs_hash128_t seed;
-	sphincs_adrs_t adrs;
-	sphincs_hash128_t dgst;
+	sphincs_hash128_t seed = {0};
+	sphincs_adrs_t adrs = {0};
+	sphincs_hash128_t dgst = {0};
 	sphincs_wots_key_t wots_pk;
 
 	sphincs_wots_sig_to_pk(wots_sig, seed, adrs, dgst, wots_pk);

--- a/tests/tlstest.c
+++ b/tests/tlstest.c
@@ -65,7 +65,7 @@ static int test_tls_encode(void)
 
 static int test_tls_null_to_bytes(void)
 {
-	uint8_t buf[10];
+	uint8_t buf[10] = {0};
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;

--- a/tests/x509_algtest.c
+++ b/tests/x509_algtest.c
@@ -34,7 +34,7 @@ static int test_x509_digest_algor(void)
 	const uint8_t *cp = buf;
 	size_t len = 0;
 	int oid;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
@@ -78,7 +78,7 @@ static int test_x509_encryption_algor(void)
 	int oid;
 	const uint8_t *params;
 	size_t paramslen;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
@@ -124,7 +124,7 @@ static int test_x509_signature_algor(void)
 	const uint8_t *cp = buf;
 	size_t len = 0;
 	int oid;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
@@ -161,7 +161,7 @@ static int test_x509_public_key_encryption_algor(void)
 	int oid;
 	const uint8_t *params;
 	size_t paramslen;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {

--- a/tests/x509_crltest.c
+++ b/tests/x509_crltest.c
@@ -27,7 +27,7 @@ static int test_x509_crl_reason(void)
 	const uint8_t *cp = buf;
 	size_t len = 0;
 	int reason;
-	int i;
+	size_t i;
 
 	for (i = 0; i < 11; i++) {
 		if (x509_crl_reason_to_der(i, &p, &len) != 1) {
@@ -38,7 +38,7 @@ static int test_x509_crl_reason(void)
 	}
 	for (i = 0; i < 11; i++) {
 		if (x509_crl_reason_from_der(&reason, &cp, &len) != 1
-			|| asn1_check(reason == i) != 1) {
+			|| asn1_check(reason == (int)i) != 1) {
 			error_print();
 			return -1;
 		}
@@ -61,7 +61,7 @@ static int test_x509_crl_entry_ext(void)
 	const uint8_t *cp = buf;
 	size_t len = 0;
 	int oid;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(exts)/sizeof(exts[0]); i++) {
 		if (x509_crl_entry_ext_id_to_der(exts[i], &p, &len) != 1) {

--- a/tests/x509_exttest.c
+++ b/tests/x509_exttest.c
@@ -311,7 +311,7 @@ static int test_x509_key_usage(void)
 	const uint8_t *cp = buf;
 	size_t len = 0;
 	int usage;
-	int i;
+	size_t i;
 
 	for (i = 0; i <= 8; i++) {
 		format_print(stderr, 0, 4, "%d %s\n", i, x509_key_usage_name(1 << i));
@@ -766,7 +766,7 @@ static int test_x509_revoke_reasons(void)
 	const uint8_t *cp = buf;
 	size_t len = 0;
 	int bits;
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
 		if (x509_revoke_reason_flags_to_der(tests[i], &p, &len) != 1) {

--- a/tests/x509_keytest.c
+++ b/tests/x509_keytest.c
@@ -139,7 +139,7 @@ static int test_x509_public_key_to_bytes(void)
 	uint8_t *p;
 	size_t len;
 	uint8_t dgst[32];
-	int i;
+	size_t i;
 
 	//format_print(stderr, 0, 4, "public_key_to_bytes size\n");
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
@@ -164,7 +164,7 @@ static int test_x509_public_key_info_to_der(void)
 {
 	X509_KEY key;
 	uint8_t buf[2048];
-	int i;
+	size_t i;
 
 	//format_print(stderr, 0, 4, "public_key_info_to_bytes size\n");
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
@@ -202,7 +202,7 @@ static int test_x509_private_key_info_to_der(void)
 {
 	X509_KEY key;
 	uint8_t buf[512];
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]) && tests[i].algor == OID_ec_public_key; i++) {
 		const uint8_t *cp = buf;
@@ -238,7 +238,7 @@ static int test_x509_private_key_info_encrypt_to_der(void)
 	const char *pass = "P@ssw0rd";
 	X509_KEY key;
 	uint8_t buf[1024];
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]) && tests[i].algor == OID_ec_public_key; i++) {
 		const uint8_t *cp = buf;
@@ -275,7 +275,7 @@ static int test_x509_private_key_info_encrypt_to_pem(void)
 	X509_KEY key;
 	uint8_t buf[1024];
 	FILE *fp;
-	int i;
+	size_t i;
 
 
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]) && tests[i].algor == OID_ec_public_key; i++) {
@@ -320,7 +320,7 @@ static int test_x509_private_key_info_decrypt_from_pem(void)
 {
 	const char *pass = "P@ssw0rd";
 	FILE *fp;
-	int i;
+	size_t i;
 
 	if (!(fp = tmpfile())) {
 		error_print();

--- a/tests/x509_oidtest.c
+++ b/tests/x509_oidtest.c
@@ -43,7 +43,7 @@ static int test_x509_name_type()
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
@@ -102,7 +102,7 @@ static int test_x509_ext_id()
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
@@ -146,7 +146,7 @@ static int test_x509_qualifier_id(void)
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
@@ -191,7 +191,7 @@ static int test_x509_cert_policy_id(void)
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
@@ -239,7 +239,7 @@ static int test_x509_key_purpose(void)
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 0, "DER\n");
 	for (i = 0; i < sizeof(names)/sizeof(names[0]); i++) {

--- a/tests/x509test.c
+++ b/tests/x509test.c
@@ -33,7 +33,7 @@ static int test_x509_version(void)
 	uint8_t *p = buf;
 	const uint8_t *cp = buf;
 	size_t len = 0;
-	int i;
+	size_t i;
 
 	format_print(stderr, 0, 4, "EXPLICIT Version(s) to DER\n");
 	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {

--- a/tests/xmsstest.c
+++ b/tests/xmsstest.c
@@ -96,7 +96,7 @@ static int test_xmss_build_root(void)
 	xmss_adrs_set_tree_address(adrs, 0);
 	xmss_build_tree(secret, seed, adrs, height, tree);
 
-	for (index = 0; index < (1 << height); index++) {
+	for (index = 0; index < ((uint32_t)1 << height); index++) {
 		xmss_build_auth_path(tree, height, index, auth_path);
 		xmss_build_root(tree[index], index, seed, adrs, auth_path, height, root);
 		if (memcmp(root, tree[sizeof(tree)/sizeof(tree[0]) - 1], sizeof(xmss_sm3_digest_t)) != 0) {
@@ -365,7 +365,7 @@ static int test_xmss_sign_update(void)
 	uint8_t sig[XMSS_SIGNATURE_MAX_SIZE];
 	size_t siglen;
 	uint8_t msg[100] = {0};
-	int i;
+	size_t i;
 	clock_t start = clock();
 
 	if (xmss_key_generate(&key, xmss_type) != 1) {

--- a/tests/zuctest.c
+++ b/tests/zuctest.c
@@ -47,7 +47,7 @@ static int test_zuc(void)
 
 	ZUC_STATE zuc_state;
 	uint32_t buf[2];
-	int i;
+	size_t i;
 
 	for (i = 0; i < 3; i++) {
 		zuc_init(&zuc_state, key[i], iv[i]);
@@ -313,7 +313,7 @@ static int test_zuc256(void)
 		 0x7a5be02e,0xc32ba585,0x505af316,0xc2f9ded2,0x7cdbd935,
 		 0xe441ce11,0x15fd0a80,0xbb7aef67,0x68989416,0xb8fac8c2}
 	};
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(key)/sizeof(key[0]); i++) {
 		ZUC_STATE zuc_key;
@@ -323,11 +323,11 @@ static int test_zuc256(void)
 		zuc_generate_keystream(&zuc_key, 20, buf);
 
 		if (memcmp(buf, ciphertext[i], 20) != 0) {
-			printf("zuc256 test %d failed\n", i);
+			printf("zuc256 test %zu failed\n", i);
 			error_print();
 			return -1;
 		} else {
-			printf("zuc256 test %d ok\n", i);
+			printf("zuc256 test %zu ok\n", i);
 		}
 	}
 
@@ -475,7 +475,7 @@ static int speed_zuc_generate_keystream(void)
 	uint32_t buf[1024]; // aligned
 	clock_t begin, end;
 	double seconds;
-	int i;
+	size_t i;
 
 	zuc_init(&zuc_state, key, iv);
 	for (i = 0; i < 4096; i++) {
@@ -503,7 +503,7 @@ static int speed_zuc_encrypt(void)
 	uint8_t *buf = (uint8_t *)align_buf;
 	clock_t begin, end;
 	double seconds;
-	int i;
+	size_t i;
 
 	zuc_init(&zuc_state, key, iv);
 	for (i = 0; i < 4096; i++) {

--- a/tools/certgen.c
+++ b/tools/certgen.c
@@ -231,7 +231,7 @@ int certgen_main(int argc, char **argv)
 		} else if (!strcmp(*argv, "-serial_len")) {
 			if (--argc < 1) goto bad;
 			serial_len = atoi(*(++argv));
-			if (serial_len <= 0 || serial_len > sizeof(serial)) {
+			if (serial_len <= 0 || (size_t)serial_len > sizeof(serial)) {
 				fprintf(stderr, "%s: invalid `-serial_len` value, need a number less than %zu\n", prog, sizeof(serial));
 				goto end;
 			}

--- a/tools/ghash.c
+++ b/tools/ghash.c
@@ -60,7 +60,7 @@ int ghash_main(int argc, char **argv)
 	FILE *outfp = stdout;
 	GHASH_CTX ghash_ctx;
 	uint8_t dgst[GHASH_SIZE];
-	int i;
+	size_t i;
 
 	argc--;
 	argv++;

--- a/tools/hsskeygen.c
+++ b/tools/hsskeygen.c
@@ -91,7 +91,7 @@ int hsskeygen_main(int argc, char **argv)
 
 			tok = strtok(lms_types_str, ":");
 			while (tok) {
-				if (levels >= sizeof(lms_types_val)/sizeof(lms_types_val[0])) {
+				if ((size_t)levels >= sizeof(lms_types_val)/sizeof(lms_types_val[0])) {
 					fprintf(stderr, "%s: too many lms types\n", prog);
 					goto end;
 				}

--- a/tools/rand.c
+++ b/tools/rand.c
@@ -82,7 +82,7 @@ bad:
 	}
 
 	while (outlen > 0) {
-		size_t len = outlen < sizeof(buf) ? outlen : sizeof(buf);
+		size_t len = (size_t)outlen < sizeof(buf) ? (size_t)outlen : sizeof(buf);
 
 		if (rdrand) {
 #ifdef ENABLE_INTEL_RDRAND

--- a/tools/reqsign.c
+++ b/tools/reqsign.c
@@ -293,7 +293,7 @@ int reqsign_main(int argc, char **argv)
 		} else if (!strcmp(*argv, "-serial_len")) {
 			if (--argc < 1) goto bad;
 			serial_len = atoi(*(++argv));
-			if (serial_len <= 0 || serial_len > sizeof(serial)) {
+			if (serial_len <= 0 || (size_t)serial_len > sizeof(serial)) {
 				fprintf(stderr, "%s: invalid `-serial_len` value, need a number less than %zu\n", prog, sizeof(serial));
 				goto end;
 			}

--- a/tools/sdfdigest.c
+++ b/tools/sdfdigest.c
@@ -80,7 +80,7 @@ int sdfdigest_main(int argc, char **argv)
 	SDF_DEVICE dev;
 	SDF_DIGEST_CTX ctx;
 	uint8_t dgst[32];
-	int i;
+	size_t i;
 
 	memset(&dev, 0, sizeof(dev));
 	memset(&ctx, 0, sizeof(ctx));

--- a/tools/sdftest.c
+++ b/tools/sdftest.c
@@ -115,7 +115,8 @@ static int test_SDF_GenerateRandom(void)
 	void *hDeviceHandle = NULL;
 	void *hSessionHandle = NULL;
 	int lengths[] = { 1, 8, 128 };
-	int ret, i;
+	int ret;
+	size_t i;
 
 	ret = SDF_OpenDevice(&hDeviceHandle);
 	if (ret != SDR_OK) {

--- a/tools/sm3.c
+++ b/tools/sm3.c
@@ -77,7 +77,7 @@ int sm3_main(int argc, char **argv)
 	size_t id_bin_len;
 	SM3_CTX sm3_ctx;
 	uint8_t dgst[32];
-	int i;
+	size_t i;
 
 	argc--;
 	argv++;

--- a/tools/sm3_pbkdf2.c
+++ b/tools/sm3_pbkdf2.c
@@ -97,7 +97,7 @@ int sm3_pbkdf2_main(int argc, char **argv)
 		} else if (!strcmp(*argv, "-outlen")) {
 			if (--argc < 1) goto bad;
 			outlen = atoi(*(++argv));
-			if (outlen < 1 || outlen > sizeof(outbuf)) {
+			if (outlen < 1 || (size_t)outlen > sizeof(outbuf)) {
 				fprintf(stderr, "gmssl %s: invalid outlen\n", prog);
 				goto end;
 			}
@@ -147,7 +147,7 @@ bad:
 	}
 
 	if (bin) {
-		if (fwrite(outbuf, 1, outlen, outfp) != outlen) {
+		if (fwrite(outbuf, 1, outlen, outfp) != (size_t)outlen) {
 			fprintf(stderr, "gmssl %s: output failure : %s\n", prog, strerror(errno));
 			goto end;
 		}

--- a/tools/sm9setup.c
+++ b/tools/sm9setup.c
@@ -43,7 +43,7 @@ int sm9setup_main(int argc, char **argv)
 	char passbuf[GMSSL_PASSWORD_MAX_SIZE] = {0};
 	char *outfile = NULL;
 	char *puboutfile = NULL;
-	int oid;
+	int oid = 0;
 	FILE *outfp = stdout;
 	FILE *puboutfp = stdout;
 	SM9_SIGN_MASTER_KEY sign_msk;

--- a/tools/tls13_client.c
+++ b/tools/tls13_client.c
@@ -253,7 +253,7 @@ int tls13_client_main(int argc, char *argv[])
 
 	// key_share
 	char  *max_key_exchanges = NULL;
-	int max_key_exchanges_cnt;
+	int max_key_exchanges_cnt = 0;
 
 	// signature_algorithms
 	int sig_algs[4];


### PR DESCRIPTION
This PR enables stricter compiler warnings for GCC/Clang builds by adding -Wall -Wextra in CMake, and cleans up the warnings found in source files, tools, and tests.

More importantly, this is not only warning cleanup: enabling broader warnings also helped uncover and fix several real bugs, including:

    a dangling pointer bug in SKF_GetAlgorName()
    an incorrect session_id_len check in TLS ServerHello parsing
    an overflow-prone PEM buffer size calculation in x509_new.c

Other changes are mainly warning-oriented cleanups, including:

    signed/unsigned comparison fixes
    declaration/definition alignment for -Warray-parameter
    explicit initialization for -Wmaybe-uninitialized false positives
    conditional compilation for forward-compatible checks where a minimum macro is currently 0

For a security-sensitive project like GmSSL, maximizing useful compiler warnings is worthwhile: much of the codebase deals with pointers, buffer lengths, integer arithmetic, and protocol parsing, where warnings often help catch real bugs early.